### PR TITLE
Puppet 5 Modules for Stream Processor 4.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@
 *.zip
 *.tar.gz
 *.rar
+*.deb
+*.rpm
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,112 @@
-# puppet-sp
+# WSO2 Stream Processor 4.2.0 Puppet 5 Modules
+
+This repository contains puppet modules for each runtime relates to Stream Processor.
+
+## Quick Start Guide
+1. Download and copy the `wso2sp-linux-installer-x64-4.2.0.deb` or/and `wso2sp-linux-installer-x64-4.2.0.rpm` to the files directories in `/etc/puppet/code/environments/dev/modules/__runtime__/files` in the Puppetmaster. <br>
+`__runtime__` refers to each runtime in Stream Processor. <br>
+eg: `/etc/puppet/code/environments/dev/modules/apim/files` <br>
+Dev refers to the sample environment that you can try these modules.
+
+2. Run necessary runtime on puppet agent. More details on this are available in the following section.
+
+## Running Stream Processor Runtimes in Puppet Agent
+This section describes how to run each Stream Processor runtime in a puppet agent.
+
+### Dashboard runtime
+```bash
+export FACTER_runtime=sp_dashboard
+puppet agent -vt
+```
+
+### Worker runtime
+```bash
+export FACTER_runtime=sp_worker
+puppet agent -vt
+```
+
+### Manager runtime
+```bash
+export FACTER_runtime=sp_manager
+puppet agent -vt
+```
+
+### Editor runtime
+```bash
+export FACTER_runtime=sp_editor
+puppet agent -vt
+```
+
+## Understanding the Project Structure
+In this project each runtime of Stream Processor is mapped to a module in puppet.
+By having this structure each puppet module is considered as a standalone runtime
+so each module can be configured individually without harming any other module.
+
+```
+puppet-sp
+├── manifests
+│   └── site.pp
+└── modules
+    ├── sp_dashboard
+    │   ├── files
+    │   │   └── ...
+    │   ├── manifests
+    │   │   ├── init.pp
+    │   │   ├── custom.pp
+    │   │   ├── params.pp
+    │   │   └── startserver.pp
+    │   └── templates
+    │       └── ...
+    ├── sp_worker
+    │   ├── files
+    │   │   └── ...
+    │   ├── manifests
+    │   │   ├── init.pp
+    │   │   ├── custom.pp
+    │   │   ├── params.pp
+    │   │   └── startserver.pp
+    │   └── templates
+    │       └── ...
+    ├── sp_manager
+    │   ├── files
+    │   │   └── ...
+    │   ├── manifests
+    │   │   ├── init.pp
+    │   │   ├── custom.pp
+    │   │   ├── params.pp
+    │   │   └── startserver.pp
+    │   └── templates
+    │       └── ...
+    ├── apim_publisher
+    │   ├── files
+    │   │   └── ...
+    │   ├── manifests
+    │   │   ├── init.pp
+    │   │   ├── custom.pp
+    │   │   ├── params.pp
+    │   │   └── startserver.pp
+    │   └── templates
+    │       └── ...
+    └── sp_editor
+        ├── files
+        │   └── ...
+        ├── manifests
+        │   ├── init.pp
+        │   ├── custom.pp
+        │   ├── params.pp
+        │   └── startserver.pp
+        └── templates
+            └── ...
+
+```
+
+### Manifests in a module
+Each puppet module contains following pp files
+- init.pp <br>
+This contains the main script of the module.
+- custom.pp <br>
+This is used to add custom user code to the runtime.
+- params.pp <br>
+This contains all the necessary parameters for main configurations and template rendering.
+- startserver.pp <br>
+This runs finally and starts the server as a service.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains puppet modules for each runtime relates to Stream Proce
 ## Quick Start Guide
 1. Download and copy the `wso2sp-linux-installer-x64-4.2.0.deb` or/and `wso2sp-linux-installer-x64-4.2.0.rpm` to the files directories in `/etc/puppet/code/environments/dev/modules/__runtime__/files` in the Puppetmaster. <br>
 `__runtime__` refers to each runtime in Stream Processor. <br>
-eg: `/etc/puppet/code/environments/dev/modules/apim/files` <br>
+eg: `/etc/puppet/code/environments/dev/modules/sp/files` <br>
 Dev refers to the sample environment that you can try these modules.
 
 2. Run necessary runtime on puppet agent. More details on this are available in the following section.
@@ -68,16 +68,6 @@ puppet-sp
     │   └── templates
     │       └── ...
     ├── sp_manager
-    │   ├── files
-    │   │   └── ...
-    │   ├── manifests
-    │   │   ├── init.pp
-    │   │   ├── custom.pp
-    │   │   ├── params.pp
-    │   │   └── startserver.pp
-    │   └── templates
-    │       └── ...
-    ├── apim_publisher
     │   ├── files
     │   │   └── ...
     │   ├── manifests

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -1,0 +1,32 @@
+#----------------------------------------------------------------------------
+#  Copyright (c) 2018 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either excustomss or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#----------------------------------------------------------------------------
+
+# Run stages
+stage { 'custom': }
+stage { 'final': }
+
+# Order stages
+Stage['main'] -> Stage['custom'] -> Stage['final']
+
+node default {
+  class { "::${::profile}": }
+  class { "::${::profile}::custom":
+    stage => 'custom'
+  }
+  class { "::${::profile}::startserver":
+    stage => 'final'
+  }
+}

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -22,11 +22,11 @@ stage { 'final': }
 Stage['main'] -> Stage['custom'] -> Stage['final']
 
 node default {
-  class { "::${::profile}": }
-  class { "::${::profile}::custom":
+  class { "::${::runtime}": }
+  class { "::${::runtime}::custom":
     stage => 'custom'
   }
-  class { "::${::profile}::startserver":
+  class { "::${::runtime}::startserver":
     stage => 'final'
   }
 }

--- a/modules/sp_dashboard/manifests/custom.pp
+++ b/modules/sp_dashboard/manifests/custom.pp
@@ -1,0 +1,21 @@
+# ----------------------------------------------------------------------------
+#  Copyright (c) 2018 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# ----------------------------------------------------------------------------
+
+# Class: sp_dashboard::custom
+# This class is reserved to run custom user code before starting the server.
+class sp_dashboard::custom {
+  # Resources
+}

--- a/modules/sp_dashboard/manifests/init.pp
+++ b/modules/sp_dashboard/manifests/init.pp
@@ -69,7 +69,7 @@ class sp_dashboard (
   $metrics_db_driver = $sp_dashboard::params::metrics_db_driver,
 
   # wso2.business.rules.manager
-  $businnes_rules_manager_username = $sp_dashboard::params::businnes_rules_manager_username,
+  $business_rules_manager_username = $sp_dashboard::params::business_rules_manager_username,
   $businnes_rules_manager_password = $sp_dashboard::params::businnes_rules_manager_password,
 
   # wso2.status.dashboard
@@ -126,7 +126,7 @@ inherits sp_dashboard::params {
     source => "puppet:///modules/${module_name}/${sp_package}",
   }
 
-  # Install WSO2 API Manager
+  # Install WSO2 Stream Processor
   package { $product_name:
     ensure   => installed,
     provider => $installer_provider,

--- a/modules/sp_dashboard/manifests/init.pp
+++ b/modules/sp_dashboard/manifests/init.pp
@@ -1,0 +1,129 @@
+# ----------------------------------------------------------------------------
+#  Copyright (c) 2018 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# ----------------------------------------------------------------------------
+
+# Class: sp
+# Init class of stream processor all in one profile
+class sp_dashboard (
+  $user                 = $sp_dashboard::params::user,
+  $user_id              = $sp_dashboard::params::user_id,
+  $user_group           = $sp_dashboard::params::user_group,
+  $user_group_id        = $sp_dashboard::params::user_group_id,
+  $product_name         = $sp_dashboard::params::product_name,
+  $service_name         = $sp_dashboard::params::service_name,
+  $service_profile = $sp_dashboard::params::service_profile,
+  $start_script_template = $sp_dashboard::params::start_script_template,
+  $deployment_yaml_template = $sp_dashboard::params::deployment_yaml_template,
+  $jre_version = $sp_dashboard::params::jre_version,
+)
+inherits sp_dashboard::params {
+
+  if $::osfamily == 'redhat' {
+    $sp_package = 'wso2sp-linux-installer-x64-4.2.0.rpm'
+    $installer_provider = 'rpm'
+    $install_path = '/usr/lib64/wso2/wso2sp/4.2.0'
+  }
+  elsif $::osfamily == 'debian' {
+    $sp_package = 'wso2sp-linux-installer-x64-4.2.0.deb'
+    $installer_provider = 'dpkg'
+    $install_path = '/usr/lib/wso2/wso2sp/4.2.0'
+  }
+
+  # Create wso2 group
+  group { $user_group:
+    ensure => present,
+    gid    => $user_group_id,
+    system => true,
+  }
+
+  # Create wso2 user
+  user { $user:
+    ensure => present,
+    uid    => $user_id,
+    gid    => $user_group_id,
+    home   => "/home/${user}",
+    system => true,
+  }
+  # Ensure the installation directory is available
+  file { "/opt/${product_name}":
+    ensure => 'directory',
+    owner  => $user,
+    group  => $user_group,
+  }
+
+  # Copy the installer to the directory
+  file { "/opt/${product_name}/${sp_package}":
+    owner  => $user,
+    group  => $user_group,
+    mode   => '0644',
+    source => "puppet:///modules/${module_name}/${sp_package}",
+  }
+
+  # Install WSO2 API Manager
+  package { $product_name:
+    ensure   => installed,
+    provider => $installer_provider,
+    source   => "/opt/${product_name}/${sp_package}"
+  }
+
+  # Change the ownership of the installation directory to wso2 user & group
+  file { $install_path:
+    ensure  => directory,
+    owner   => $user,
+    group   => $user_group,
+    require => [ User[$user], Group[$user_group]],
+    recurse => true
+  }
+
+  # Copy deployment.yaml to the installed directory
+  file { "${install_path}/${deployment_yaml_template}":
+    ensure  => file,
+    owner   => $user,
+    group   => $user_group,
+    mode    => '0644',
+    content => template("${module_name}/carbon-home/${deployment_yaml_template}.erb")
+  }
+
+  # Copy dashboard.sh to installed directory
+  file { "${install_path}/${start_script_template}":
+    ensure  => file,
+    owner   => $user,
+    group   => $user_group,
+    mode    => '0754',
+    content => template("${module_name}/carbon-home/${start_script_template}.erb")
+  }
+
+  # Copy the unit file required to deploy the server as a service
+  file { "/etc/systemd/system/${service_name}.service":
+    ensure  => present,
+    owner   => root,
+    group   => root,
+    mode    => '0754',
+    content => template("${module_name}/${service_name}.service.erb"),
+  }
+
+  /*
+    Following script can be used to copy file to a given location.
+    This will copy some_file to install_path -> repository.
+    Note: Ensure
+    that file is available in modules -> sp_dashboard -> files
+  */
+  # file { "${install_path}/repository/some_file":
+  #   owner  => $user,
+  #   group  => $user_group,
+  #   mode   => '0644',
+  #   source => "puppet:///modules/${module_name}/some_file",
+  # }
+}

--- a/modules/sp_dashboard/manifests/init.pp
+++ b/modules/sp_dashboard/manifests/init.pp
@@ -17,16 +17,71 @@
 # Class: sp
 # Init class of stream processor all in one profile
 class sp_dashboard (
-  $user                 = $sp_dashboard::params::user,
-  $user_id              = $sp_dashboard::params::user_id,
-  $user_group           = $sp_dashboard::params::user_group,
-  $user_group_id        = $sp_dashboard::params::user_group_id,
-  $product_name         = $sp_dashboard::params::product_name,
-  $service_name         = $sp_dashboard::params::service_name,
+  $user = $sp_dashboard::params::user,
+  $user_id = $sp_dashboard::params::user_id,
+  $user_group = $sp_dashboard::params::user_group,
+  $user_group_id = $sp_dashboard::params::user_group_id,
+  $product_name = $sp_dashboard::params::product_name,
+  $service_name = $sp_dashboard::params::service_name,
   $service_profile = $sp_dashboard::params::service_profile,
   $start_script_template = $sp_dashboard::params::start_script_template,
   $deployment_yaml_template = $sp_dashboard::params::deployment_yaml_template,
   $jre_version = $sp_dashboard::params::jre_version,
+
+  # -------- deployment.yaml configs --------
+
+  # databridge.config
+  $databridge_keystore_location = $sp_dashboard::params::databridge_keystore_location,
+  $databridge_keystore_password = $sp_dashboard::params::databridge_keystore_password,
+  $binary_data_receiver_hostname = $sp_dashboard::params::binary_data_receiver_hostname,
+
+  # data.agent.config
+  $thrift_agent_trust_store = $sp_dashboard::params::thrift_agent_trust_store,
+  $thrift_agent_trust_store_password = $sp_dashboard::params::thrift_agent_trust_store_password,
+  $binary_agent_trust_store = $sp_dashboard::params::binary_agent_trust_store,
+  $binary_agent_trust_store_password = $sp_dashboard::params::binary_agent_trust_store_password,
+
+  # wso2.securevault
+  $securevault_private_key_alias = $sp_dashboard::params::securevault_private_key_alias,
+  $securevault_key_store = $sp_dashboard::params::securevault_key_store,
+  $securevault_secret_properties_file = $sp_dashboard::params::securevault_secret_properties_file,
+  $securevault_master_key_reader_file = $sp_dashboard::params::securevault_master_key_reader_file,
+
+  # wso2.datasources
+  $dashboard_db_url = $sp_dashboard::params::dashboard_db_url,
+  $dashboard_db_username = $sp_dashboard::params::dashboard_db_username,
+  $dashboard_db_password = $sp_dashboard::params::dashboard_db_password,
+  $dashboard_db_driver = $sp_dashboard::params::dashboard_db_driver,
+
+  $business_rules_db_url = $sp_dashboard::params::business_rules_db_url,
+  $business_rules_db_username = $sp_dashboard::params::business_rules_db_username,
+  $business_rules_db_password = $sp_dashboard::params::business_rules_db_password,
+  $business_rules_db_driver = $sp_dashboard::params::business_rules_db_driver,
+
+  $status_dashboard_db_url = $sp_dashboard::params::status_dashboard_db_url,
+  $status_dashboard_db_username = $sp_dashboard::params::status_dashboard_db_username,
+  $status_dashboard_db_password = $sp_dashboard::params::status_dashboard_db_password,
+  $status_dashboard_db_driver = $sp_dashboard::params::status_dashboard_db_driver,
+
+  $metrics_db_url = $sp_dashboard::params::metrics_db_url,
+  $metrics_db_username = $sp_dashboard::params::metrics_db_username,
+  $metrics_db_password = $sp_dashboard::params::metrics_db_password,
+  $metrics_db_driver = $sp_dashboard::params::metrics_db_driver,
+
+  # wso2.business.rules.manager
+  $businnes_rules_manager_username = $sp_dashboard::params::businnes_rules_manager_username,
+  $businnes_rules_manager_password = $sp_dashboard::params::businnes_rules_manager_password,
+
+  # wso2.status.dashboard
+  $worker_access_username = $sp_dashboard::params::worker_access_username,
+  $worker_access_password = $sp_dashboard::params::worker_access_password,
+
+  # listenerConfigurations
+  $listener_host = $sp_dashboard::params::listener_host,
+  $listener_keystore_file = $sp_dashboard::params::listener_keystore_file,
+  $listener_keystore_password = $sp_dashboard::params::listener_keystore_password,
+  $listener_cert_pass = $sp_dashboard::params::listener_cert_pass,
+
 )
 inherits sp_dashboard::params {
 

--- a/modules/sp_dashboard/manifests/params.pp
+++ b/modules/sp_dashboard/manifests/params.pp
@@ -1,0 +1,33 @@
+# ----------------------------------------------------------------------------
+#  Copyright (c) 2018 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# ----------------------------------------------------------------------------
+
+# Claas sp_dashboard::params
+# This class includes all the necessary parameters
+class sp_dashboard::params {
+  $user = 'wso2carbon'
+  $user_id = 802
+  $user_group = 'wso2'
+  $user_home = '/home/$user'
+  $user_group_id = 802
+  $product_name = 'wso2sp'
+  $product_profile = 'dashboard'
+  $service_name = "${product_name}-${product_profile}"
+  $jre_version = 'jre1.8.0_172'
+
+  # Define the template
+  $start_script_template = "bin/${product_profile}.sh"
+  $deployment_yaml_template = "conf/${product_profile}/deployment.yaml"
+}

--- a/modules/sp_dashboard/manifests/params.pp
+++ b/modules/sp_dashboard/manifests/params.pp
@@ -72,7 +72,7 @@ class sp_dashboard::params {
   $metrics_db_driver = 'org.h2.Driver'
 
   # wso2.business.rules.manager
-  $businnes_rules_manager_username = 'admin'
+  $business_rules_manager_username = 'admin'
   $businnes_rules_manager_password = 'admin'
 
   # wso2.status.dashboard

--- a/modules/sp_dashboard/manifests/params.pp
+++ b/modules/sp_dashboard/manifests/params.pp
@@ -30,4 +30,58 @@ class sp_dashboard::params {
   # Define the template
   $start_script_template = "bin/${product_profile}.sh"
   $deployment_yaml_template = "conf/${product_profile}/deployment.yaml"
+
+  # -------- deployment.yaml configs --------
+
+  # databridge.config
+  $databridge_keystore_location = '${sys:carbon.home}/resources/security/wso2carbon.jks'
+  $databridge_keystore_password = 'wso2carbon'
+  $binary_data_receiver_hostname = '0.0.0.0'
+
+  # data.agent.config
+  $thrift_agent_trust_store = '${sys:carbon.home}/resources/security/client-truststore.jks'
+  $thrift_agent_trust_store_password = 'wso2carbon'
+  $binary_agent_trust_store = '${sys:carbon.home}/resources/security/client-truststore.jks'
+  $binary_agent_trust_store_password = 'wso2carbon'
+
+  # wso2.securevault
+  $securevault_private_key_alias = 'wso2carbon'
+  $securevault_key_store = '${sys:carbon.home}/resources/security/securevault.jks'
+  $securevault_secret_properties_file = '${sys:carbon.home}/conf/${sys:wso2.runtime}/secrets.properties'
+  $securevault_master_key_reader_file = '${sys:carbon.home}/conf/${sys:wso2.runtime}/master-keys.yaml'
+
+  # wso2.datasources
+  $dashboard_db_url = 'jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/DASHBOARD_DB;IFEXISTS=TRUE;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;MVCC=TRUE'
+  $dashboard_db_username = 'wso2carbon'
+  $dashboard_db_password = 'wso2carbon'
+  $dashboard_db_driver = 'org.h2.Driver'
+
+  $business_rules_db_url = 'jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/BUSINESS_RULES_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;MVCC=TRUE'
+  $business_rules_db_username = 'wso2carbon'
+  $business_rules_db_password = 'wso2carbon'
+  $business_rules_db_driver = 'org.h2.Driver'
+
+  $status_dashboard_db_url = 'jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/wso2_status_dashboard;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;MVCC=TRUE'
+  $status_dashboard_db_username = 'wso2carbon'
+  $status_dashboard_db_password = 'wso2carbon'
+  $status_dashboard_db_driver = 'org.h2.Driver'
+
+  $metrics_db_url = 'jdbc:h2:${sys:carbon.home}/wso2/dashboard/database/metrics;AUTO_SERVER=TRUE'
+  $metrics_db_username = 'wso2carbon'
+  $metrics_db_password = 'wso2carbon'
+  $metrics_db_driver = 'org.h2.Driver'
+
+  # wso2.business.rules.manager
+  $businnes_rules_manager_username = 'admin'
+  $businnes_rules_manager_password = 'admin'
+
+  # wso2.status.dashboard
+  $worker_access_username = 'admin'
+  $worker_access_password = 'admin'
+
+  # listenerConfigurations
+  $listener_host = '0.0.0.0'
+  $listener_keystore_file = '${carbon.home}/resources/security/wso2carbon.jks'
+  $listener_keystore_password = 'wso2carbon'
+  $listener_cert_pass = 'wso2carbon'
 }

--- a/modules/sp_dashboard/manifests/startserver.pp
+++ b/modules/sp_dashboard/manifests/startserver.pp
@@ -1,0 +1,28 @@
+# ----------------------------------------------------------------------------
+#  Copyright (c) 2018 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# ----------------------------------------------------------------------------
+
+# Class sp_dashboard::startserver
+#
+class sp_dashboard::startserver (
+  $service_name = $sp_dashboard::params::service_name
+)
+  inherits sp_dashboard::params {
+
+  service { $service_name:
+    ensure => running,
+    enable => true
+  }
+}

--- a/modules/sp_dashboard/templates/carbon-home/bin/dashboard.sh.erb
+++ b/modules/sp_dashboard/templates/carbon-home/bin/dashboard.sh.erb
@@ -1,0 +1,68 @@
+#!/bin/sh
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+export JAVA_HOME="<%=@install_path%>/jre/<%=@jre_version%>"
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+             JAVA_VERSION="CurrentJDK"
+           else
+             echo "Using Java version: $JAVA_VERSION"
+           fi
+           if [ -z "$JAVA_HOME" ] ; then
+             JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+           fi
+           ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+[ -z "$RUNTIME_HOME" ] && RUNTIME_HOME=`cd "$PRGDIR/../wso2/dashboard" ; pwd`
+
+###########################################################################
+NAME=start-dashboard
+# Daemon name, where is the actual executable
+
+DASHBOARD_INIT_SCRIPT="$CARBON_HOME/wso2/dashboard/bin/carbon.sh"
+
+# If the daemon is not there, then exit.
+
+$DASHBOARD_INIT_SCRIPT $*
+exit;

--- a/modules/sp_dashboard/templates/carbon-home/conf/dashboard/deployment.yaml.erb
+++ b/modules/sp_dashboard/templates/carbon-home/conf/dashboard/deployment.yaml.erb
@@ -38,10 +38,10 @@ databridge.config:
   eventBufferSize: 2000
     # Keystore file path
     # THIS IS A MANDATORY FIELD
-  keyStoreLocation : ${sys:carbon.home}/resources/security/wso2carbon.jks
+  keyStoreLocation : <%= @databridge_keystore_location %>
     # Keystore password
     # THIS IS A MANDATORY FIELD
-  keyStorePassword : wso2carbon
+  keyStorePassword : <%= @databridge_keystore_password %>
     # Session Timeout value in mins
     # THIS IS A MANDATORY FIELD
   clientTimeoutMin: 30
@@ -71,7 +71,7 @@ databridge.config:
         sslPort: '9711'
         tcpReceiverThreadPoolSize: '100'
         sslReceiverThreadPoolSize: '100'
-        hostName: 0.0.0.0
+        hostName: <%= @binary_data_receiver_hostname %>
 
   # Configuration of the Data Agents - to publish events through databridge
 data.agent.config:
@@ -90,9 +90,9 @@ data.agent.config:
         # Data publisher strategy
       publishingStrategy: async
         # Trust store path
-      trustStorePath: '${sys:carbon.home}/resources/security/client-truststore.jks'
+      trustStorePath: '<%= @thrift_agent_trust_store %>'
         # Trust store password
-      trustStorePassword: 'wso2carbon'
+      trustStorePassword: '<%= @thrift_agent_trust_store_password %>'
         # Queue Size
       queueSize: 32768
         # Batch Size
@@ -139,9 +139,9 @@ data.agent.config:
         # Data publisher strategy
       publishingStrategy: async
         # Trust store path
-      trustStorePath: '${sys:carbon.home}/resources/security/client-truststore.jks'
+      trustStorePath: '<%= @binary_agent_trust_store %>'
         # Trust store password
-      trustStorePassword: 'wso2carbon'
+      trustStorePassword: '<%= @binary_agent_trust_store_password %>'
         # Queue Size
       queueSize: 32768
         # Batch Size
@@ -196,13 +196,13 @@ wso2.securevault:
   secretRepository:
     type: org.wso2.carbon.secvault.repository.DefaultSecretRepository
     parameters:
-      privateKeyAlias: wso2carbon
-      keystoreLocation: ${sys:carbon.home}/resources/security/securevault.jks
-      secretPropertiesFile: ${sys:carbon.home}/conf/${sys:wso2.runtime}/secrets.properties
+      privateKeyAlias: <%= @securevault_private_key_alias %>
+      keystoreLocation: <%= @securevault_key_store %>
+      secretPropertiesFile: <%= @securevault_secret_properties_file %>
   masterKeyReader:
     type: org.wso2.carbon.secvault.reader.DefaultMasterKeyReader
     parameters:
-      masterKeyReaderFile: ${sys:carbon.home}/conf/${sys:wso2.runtime}/master-keys.yaml
+      masterKeyReaderFile: <%= @securevault_master_key_reader_file %>
 
 
 # Data Sources Configuration
@@ -217,10 +217,10 @@ wso2.datasources:
     definition:
       type: RDBMS
       configuration:
-        jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/DASHBOARD_DB;IFEXISTS=TRUE;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;MVCC=TRUE'
-        username: wso2carbon
-        password: wso2carbon
-        driverClassName: org.h2.Driver
+        jdbcUrl: '<%= @dashboard_db_url %>'
+        username: <%= @dashboard_db_username %>
+        password: <%= @dashboard_db_password %>
+        driverClassName: <%= @dashboard_db_driver %>
         maxPoolSize: 50
         idleTimeout: 60000
         connectionTestQuery: SELECT 1
@@ -234,10 +234,10 @@ wso2.datasources:
     definition:
       type: RDBMS
       configuration:
-        jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/BUSINESS_RULES_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;MVCC=TRUE'
-        username: wso2carbon
-        password: wso2carbon
-        driverClassName: org.h2.Driver
+        jdbcUrl: '<%= @business_rules_db_url %>'
+        username: <%= @business_rules_db_username %>
+        password: <%= @business_rules_db_password %>
+        driverClassName: <%= @business_rules_db_driver %>
         maxPoolSize: 50
         idleTimeout: 60000
         connectionTestQuery: SELECT 1
@@ -270,10 +270,10 @@ wso2.datasources:
     definition:
       type: RDBMS
       configuration:
-        jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/wso2_status_dashboard;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;MVCC=TRUE'
-        username: wso2carbon
-        password: wso2carbon
-        driverClassName: org.h2.Driver
+        jdbcUrl: '<%= @status_dashboard_db_url %>'
+        username: <%= @status_dashboard_db_username %>
+        password: <%= @status_dashboard_db_password %>
+        driverClassName: <%= @status_dashboard_db_driver %>
         maxPoolSize: 50
         idleTimeout: 60000
         connectionTestQuery: SELECT 1
@@ -288,10 +288,10 @@ wso2.datasources:
     definition:
       type: RDBMS
       configuration:
-        jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/dashboard/database/metrics;AUTO_SERVER=TRUE'
-        username: wso2carbon
-        password: wso2carbon
-        driverClassName: org.h2.Driver
+        jdbcUrl: '<%= @metrics_db_url %>'
+        username: <%= @metrics_db_username %>
+        password: <%= @metrics_db_password %>
+        driverClassName: <%= @metrics_db_driver %>
         maxPoolSize: 50
         idleTimeout: 60000
         connectionTestQuery: SELECT 1
@@ -383,16 +383,16 @@ wso2.business.rules.manager:
        - message-tracing-source-template
        - message-tracing-app-template
   # credentials for worker nodes
-  username: admin
-  password: admin
+  username: <%= @businnes_rules_manager_username %>
+  password: <%= @businnes_rules_manager_password %>
 
 wso2.status.dashboard:
   pollingInterval: 5
   metricsDatasourceName: 'WSO2_METRICS_DB'
   dashboardDatasourceName: 'WSO2_STATUS_DASHBOARD_DB'
   workerAccessCredentials:
-    username: 'admin'
-    password: 'admin'
+    username: '<%= @worker_access_username %>'
+    password: '<%= @worker_access_password %>'
   queries:
     -
      mappings:
@@ -433,9 +433,9 @@ wso2.transport.http:
 
   listenerConfigurations:
     - id: "default-https"
-      host: "0.0.0.0"
+      host: "<%= @listener_host %>"
       port: 9643
       scheme: https
-      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
-      keyStorePassword: wso2carbon
-      certPass: wso2carbon
+      keyStoreFile: "<%= @listener_keystore_file %>"
+      keyStorePassword: <%= @listener_keystore_password %>
+      certPass: <%= @listener_cert_pass %>

--- a/modules/sp_dashboard/templates/carbon-home/conf/dashboard/deployment.yaml.erb
+++ b/modules/sp_dashboard/templates/carbon-home/conf/dashboard/deployment.yaml.erb
@@ -383,7 +383,7 @@ wso2.business.rules.manager:
        - message-tracing-source-template
        - message-tracing-app-template
   # credentials for worker nodes
-  username: <%= @businnes_rules_manager_username %>
+  username: <%= @business_rules_manager_username %>
   password: <%= @businnes_rules_manager_password %>
 
 wso2.status.dashboard:

--- a/modules/sp_dashboard/templates/carbon-home/conf/dashboard/deployment.yaml.erb
+++ b/modules/sp_dashboard/templates/carbon-home/conf/dashboard/deployment.yaml.erb
@@ -1,0 +1,441 @@
+################################################################################
+#   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved
+#
+#   Licensed under the Apache License, Version 2.0 (the \"License\");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an \"AS IS\" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+################################################################################
+
+  # Carbon Configuration Parameters
+wso2.carbon:
+    # value to uniquely identify a server
+  id: wso2-sp
+    # server name
+  name: WSO2 Stream Processor
+    # ports used by this server
+  ports:
+      # port offset
+    offset: 2
+
+  # Configuration used for the databridge communication
+databridge.config:
+    # No of worker threads to consume events
+    # THIS IS A MANDATORY FIELD
+  workerThreads: 10
+    # Maximum amount of messages that can be queued internally in MB
+    # THIS IS A MANDATORY FIELD
+  maxEventBufferCapacity: 10000000
+    # Queue size; the maximum number of events that can be stored in the queue
+    # THIS IS A MANDATORY FIELD
+  eventBufferSize: 2000
+    # Keystore file path
+    # THIS IS A MANDATORY FIELD
+  keyStoreLocation : ${sys:carbon.home}/resources/security/wso2carbon.jks
+    # Keystore password
+    # THIS IS A MANDATORY FIELD
+  keyStorePassword : wso2carbon
+    # Session Timeout value in mins
+    # THIS IS A MANDATORY FIELD
+  clientTimeoutMin: 30
+    # Data receiver configurations
+    # THIS IS A MANDATORY FIELD
+  dataReceivers:
+  -
+      # Data receiver configuration
+    dataReceiver:
+        # Data receiver type
+        # THIS IS A MANDATORY FIELD
+      type: Thrift
+        # Data receiver properties
+      properties:
+        tcpPort: '7611'
+        sslPort: '7711'
+
+  -
+      # Data receiver configuration
+    dataReceiver:
+        # Data receiver type
+        # THIS IS A MANDATORY FIELD
+      type: Binary
+        # Data receiver properties
+      properties:
+        tcpPort: '9611'
+        sslPort: '9711'
+        tcpReceiverThreadPoolSize: '100'
+        sslReceiverThreadPoolSize: '100'
+        hostName: 0.0.0.0
+
+  # Configuration of the Data Agents - to publish events through databridge
+data.agent.config:
+    # Data agent configurations
+    # THIS IS A MANDATORY FIELD
+  agents:
+  -
+      # Data agent configuration
+    agentConfiguration:
+        # Data agent name
+        # THIS IS A MANDATORY FIELD
+      name: Thrift
+        # Data endpoint class
+        # THIS IS A MANDATORY FIELD
+      dataEndpointClass: org.wso2.carbon.databridge.agent.endpoint.thrift.ThriftDataEndpoint
+        # Data publisher strategy
+      publishingStrategy: async
+        # Trust store path
+      trustStorePath: '${sys:carbon.home}/resources/security/client-truststore.jks'
+        # Trust store password
+      trustStorePassword: 'wso2carbon'
+        # Queue Size
+      queueSize: 32768
+        # Batch Size
+      batchSize: 200
+        # Core pool size
+      corePoolSize: 1
+        # Socket timeout in milliseconds
+      socketTimeoutMS: 30000
+        # Maximum pool size
+      maxPoolSize: 1
+        # Keep alive time in pool
+      keepAliveTimeInPool: 20
+        # Reconnection interval
+      reconnectionInterval: 30
+        # Max transport pool size
+      maxTransportPoolSize: 250
+        # Max idle connections
+      maxIdleConnections: 250
+        # Eviction time interval
+      evictionTimePeriod: 5500
+        # Min idle time in pool
+      minIdleTimeInPool: 5000
+        # Secure max transport pool size
+      secureMaxTransportPoolSize: 250
+        # Secure max idle connections
+      secureMaxIdleConnections: 250
+        # secure eviction time period
+      secureEvictionTimePeriod: 5500
+        # Secure min idle time in pool
+      secureMinIdleTimeInPool: 5000
+        # SSL enabled protocols
+      sslEnabledProtocols: TLSv1.1,TLSv1.2
+        # Ciphers
+      ciphers: TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
+  -
+      # Data agent configuration
+    agentConfiguration:
+        # Data agent name
+        # THIS IS A MANDATORY FIELD
+      name: Binary
+        # Data endpoint class
+        # THIS IS A MANDATORY FIELD
+      dataEndpointClass: org.wso2.carbon.databridge.agent.endpoint.binary.BinaryDataEndpoint
+        # Data publisher strategy
+      publishingStrategy: async
+        # Trust store path
+      trustStorePath: '${sys:carbon.home}/resources/security/client-truststore.jks'
+        # Trust store password
+      trustStorePassword: 'wso2carbon'
+        # Queue Size
+      queueSize: 32768
+        # Batch Size
+      batchSize: 200
+        # Core pool size
+      corePoolSize: 1
+        # Socket timeout in milliseconds
+      socketTimeoutMS: 30000
+        # Maximum pool size
+      maxPoolSize: 1
+        # Keep alive time in pool
+      keepAliveTimeInPool: 20
+        # Reconnection interval
+      reconnectionInterval: 30
+        # Max transport pool size
+      maxTransportPoolSize: 250
+        # Max idle connections
+      maxIdleConnections: 250
+        # Eviction time interval
+      evictionTimePeriod: 5500
+        # Min idle time in pool
+      minIdleTimeInPool: 5000
+        # Secure max transport pool size
+      secureMaxTransportPoolSize: 250
+        # Secure max idle connections
+      secureMaxIdleConnections: 250
+        # secure eviction time period
+      secureEvictionTimePeriod: 5500
+        # Secure min idle time in pool
+      secureMinIdleTimeInPool: 5000
+        # SSL enabled protocols
+      sslEnabledProtocols: TLSv1.1,TLSv1.2
+        # Ciphers
+      ciphers: TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
+
+  # Deployment configuration parameters
+wso2.artifact.deployment:
+    # Scheduler update interval
+  updateInterval: 5
+
+  # HA Configuration
+state.persistence:
+  enabled: false
+  intervalInMin: 1
+  revisionsToKeep: 2
+  persistenceStore: org.wso2.carbon.stream.processor.core.persistence.FileSystemPersistenceStore
+  config:
+    location: siddhi-app-persistence
+
+  # Secure Vault Configuration
+wso2.securevault:
+  secretRepository:
+    type: org.wso2.carbon.secvault.repository.DefaultSecretRepository
+    parameters:
+      privateKeyAlias: wso2carbon
+      keystoreLocation: ${sys:carbon.home}/resources/security/securevault.jks
+      secretPropertiesFile: ${sys:carbon.home}/conf/${sys:wso2.runtime}/secrets.properties
+  masterKeyReader:
+    type: org.wso2.carbon.secvault.reader.DefaultMasterKeyReader
+    parameters:
+      masterKeyReaderFile: ${sys:carbon.home}/conf/${sys:wso2.runtime}/master-keys.yaml
+
+
+# Data Sources Configuration
+wso2.datasources:
+  dataSources:
+  # Dashboard data source
+  - name: WSO2_DASHBOARD_DB
+    description: The datasource used for dashboard feature
+    jndiConfig:
+      name: jdbc/DASHBOARD_DB
+      useJndiReference: true
+    definition:
+      type: RDBMS
+      configuration:
+        jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/DASHBOARD_DB;IFEXISTS=TRUE;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;MVCC=TRUE'
+        username: wso2carbon
+        password: wso2carbon
+        driverClassName: org.h2.Driver
+        maxPoolSize: 50
+        idleTimeout: 60000
+        connectionTestQuery: SELECT 1
+        validationTimeout: 30000
+        isAutoCommit: false
+  - name: BUSINESS_RULES_DB
+    description: The datasource used for dashboard feature
+    jndiConfig:
+      name: jdbc/BUSINESS_RULES_DB
+      useJndiReference: true
+    definition:
+      type: RDBMS
+      configuration:
+        jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/BUSINESS_RULES_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;MVCC=TRUE'
+        username: wso2carbon
+        password: wso2carbon
+        driverClassName: org.h2.Driver
+        maxPoolSize: 50
+        idleTimeout: 60000
+        connectionTestQuery: SELECT 1
+        validationTimeout: 30000
+        isAutoCommit: false
+  - name: SAMPLE_DB
+    description: Sample datasource used for gadgets generation wizard
+    jndiConfig:
+      name: jdbc/SAMPLE_DB
+      useJndiReference: true
+    definition:
+      type: RDBMS
+      configuration:
+        jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/SAMPLE_DB;IFEXISTS=TRUE;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;MVCC=TRUE'
+        username: wso2carbon
+        password: wso2carbon
+        driverClassName: org.h2.Driver
+        maxPoolSize: 50
+        idleTimeout: 60000
+        connectionTestQuery: SELECT 1
+        validationTimeout: 30000
+        isAutoCommit: false
+
+  # Dashboard data source
+  - name: WSO2_STATUS_DASHBOARD_DB
+    description: The datasource used for dashboard feature
+    jndiConfig:
+      name: jdbc/wso2_status_dashboard
+      useJndiReference: true
+    definition:
+      type: RDBMS
+      configuration:
+        jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/wso2_status_dashboard;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;MVCC=TRUE'
+        username: wso2carbon
+        password: wso2carbon
+        driverClassName: org.h2.Driver
+        maxPoolSize: 50
+        idleTimeout: 60000
+        connectionTestQuery: SELECT 1
+        validationTimeout: 30000
+        isAutoCommit: false
+
+  # carbon metrics data source
+  - name: WSO2_METRICS_DB
+    description: The datasource used for dashboard feature
+    jndiConfig:
+      name: jdbc/WSO2MetricsDB
+    definition:
+      type: RDBMS
+      configuration:
+        jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/dashboard/database/metrics;AUTO_SERVER=TRUE'
+        username: wso2carbon
+        password: wso2carbon
+        driverClassName: org.h2.Driver
+        maxPoolSize: 50
+        idleTimeout: 60000
+        connectionTestQuery: SELECT 1
+        validationTimeout: 30000
+        isAutoCommit: false
+
+  - name: WSO2_PERMISSIONS_DB
+    description: The datasource used for dashboard feature
+    jndiConfig:
+      name: jdbc/PERMISSION_DB
+      useJndiReference: true
+    definition:
+      type: RDBMS
+      configuration:
+        jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/PERMISSION_DB;IFEXISTS=TRUE;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;MVCC=TRUE'
+        username: wso2carbon
+        password: wso2carbon
+        driverClassName: org.h2.Driver
+        maxPoolSize: 50
+        idleTimeout: 60000
+        connectionTestQuery: SELECT 1
+        validationTimeout: 30000
+        isAutoCommit: false
+  - name: HTTP_ANALYTICS_DB
+    description: The datasource used for HTTP Analytics dashboard
+    jndiConfig:
+      name: jdbc/HTTP_ANALYTICS_DB
+      useJndiReference: false
+    definition:
+      type: RDBMS
+      configuration:
+        jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/worker/database/HTTP_ANALYTICS_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;MVCC=TRUE;AUTO_SERVER=TRUE'
+        username: wso2carbon
+        password: wso2carbon
+        driverClassName: org.h2.Driver
+        maxPoolSize: 50
+        idleTimeout: 60000
+        connectionTestQuery: SELECT 1
+        validationTimeout: 30000
+        isAutoCommit: false
+  - name: Twitter_Analytics
+    description: The datasource used for Twitter Analytics dashboard
+    jndiConfig:
+      name: jdbc/Twitter_Analytics
+      useJndiReference: false
+    definition:
+      type: RDBMS
+      configuration:
+        jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/worker/database/Twitter_Analytics;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;MVCC=TRUE;AUTO_SERVER=TRUE'
+        username: wso2carbon
+        password: wso2carbon
+        driverClassName: org.h2.Driver
+        maxPoolSize: 50
+        idleTimeout: 60000
+        connectionTestQuery: SELECT 1
+        validationTimeout: 30000
+        isAutoCommit: false
+  - name: Message_Tracing_DB
+    description: "The datasource used for message tracer to store span information."
+    jndiConfig:
+      name: jdbc/Message_Tracing_DB
+    definition:
+      type: RDBMS
+      configuration:
+        jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/dashboard/database/MESSAGE_TRACING_DB;AUTO_SERVER=TRUE'
+        username: wso2carbon
+        password: wso2carbon
+        driverClassName: org.h2.Driver
+        maxPoolSize: 50
+        idleTimeout: 60000
+        connectionTestQuery: SELECT 1
+        validationTimeout: 30000
+        isAutoCommit: false
+
+wso2.business.rules.manager:
+  datasource: BUSINESS_RULES_DB
+  # rule template wise configuration for deploying business rules
+  deployment_configs:
+    -
+     # <IP>:<HTTPS Port> of the Worker node
+     localhost:9443:
+       # UUIDs of rule templates that are needed to be deployed on the node
+       - stock-data-analysis
+       - stock-exchange-input
+       - stock-exchange-output
+       - identifying-continuous-production-decrease
+       - popular-tweets-analysis
+       - http-analytics-processing
+       - message-tracing-source-template
+       - message-tracing-app-template
+  # credentials for worker nodes
+  username: admin
+  password: admin
+
+wso2.status.dashboard:
+  pollingInterval: 5
+  metricsDatasourceName: 'WSO2_METRICS_DB'
+  dashboardDatasourceName: 'WSO2_STATUS_DASHBOARD_DB'
+  workerAccessCredentials:
+    username: 'admin'
+    password: 'admin'
+  queries:
+    -
+     mappings:
+        tableCreateQuery:
+        foreignKeyQuery:
+        tableCheckQuery:
+        recordSelectQuery:
+        recordSelectAppMetricsQuery:
+        recordSelectAgregatedAppMetricsQuery:
+        recordSelectWorkerThroughputQuery:
+        recordSelectWorkerAggregateThroughputQuery:
+        recordSelectWorkerMetricsQuery:
+        recordSelectWorkerAggregateMetricsQuery:
+        recordInsertQuery:
+        recordDeleteQuery:
+        selectAppComponentList:
+        selectAppComponentMetrics:
+        selectAppComponentHistory:
+        selectAppComponentAggregatedHistory:
+        doubleType:
+        floatType:
+        integerType:
+        longType:
+        stringType:
+        booleanType:
+
+     type: default
+     version: default
+
+wso2.transport.http:
+  transportProperties:
+    - name: "server.bootstrap.socket.timeout"
+      value: 60
+    - name: "client.bootstrap.socket.timeout"
+      value: 60
+    - name: "latency.metrics.enabled"
+      value: true
+
+  listenerConfigurations:
+    - id: "default-https"
+      host: "0.0.0.0"
+      port: 9643
+      scheme: https
+      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
+      keyStorePassword: wso2carbon
+      certPass: wso2carbon

--- a/modules/sp_dashboard/templates/wso2sp-dashboard.service.erb
+++ b/modules/sp_dashboard/templates/wso2sp-dashboard.service.erb
@@ -1,0 +1,19 @@
+[Unit]
+Description=WSO2 Stream Processor - Dashboard
+After=network.target
+
+[Service]
+ExecStart=<%=@install_path%>/bin/<%=@product_profile%>.sh start
+ExecStop=<%=@install_path%>/bin/<%=@product_profile%>.sh stop
+ExecRestart=<%=@install_path%>/bin/<%=@product_profile%>.sh restart
+PIDFile=<%=@install_path%>/wso2/<%=@product_profile%>/runtime.pid
+User=<%=@user%>
+Group=<%=@user_group%>
+Type=forking
+Restart=on-failure
+RestartSec=5
+StartLimitInterval=60s
+StartLimitBurst=3
+
+[Install]
+WantedBy=multi-user.target

--- a/modules/sp_editor/manifests/custom.pp
+++ b/modules/sp_editor/manifests/custom.pp
@@ -1,0 +1,21 @@
+# ----------------------------------------------------------------------------
+#  Copyright (c) 2018 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# ----------------------------------------------------------------------------
+
+# Class: sp_editor::custom
+# This class is reserved to run custom user code before starting the server.
+class sp_editor::custom {
+
+}

--- a/modules/sp_editor/manifests/init.pp
+++ b/modules/sp_editor/manifests/init.pp
@@ -1,0 +1,129 @@
+# ----------------------------------------------------------------------------
+#  Copyright (c) 2018 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# ----------------------------------------------------------------------------
+
+# Class: sp_editor
+# Init class of stream processor all in one profile
+class sp_editor (
+  $user                 = $sp_editor::params::user,
+  $user_id              = $sp_editor::params::user_id,
+  $user_group           = $sp_editor::params::user_group,
+  $user_group_id        = $sp_editor::params::user_group_id,
+  $product_name         = $sp_editor::params::product_name,
+  $service_name         = $sp_editor::params::service_name,
+  $service_profile = $sp_editor::params::service_profile,
+  $start_script_template = $sp_editor::params::start_script_template,
+  $deployment_yaml_template = $sp_editor::params::deployment_yaml_template,
+  $jre_version = $sp_editor::params::jre_version,
+)
+inherits sp_editor::params {
+
+  if $::osfamily == 'redhat' {
+    $sp_package = 'wso2sp-linux-installer-x64-4.2.0.rpm'
+    $installer_provider = 'rpm'
+    $install_path = '/usr/lib64/wso2/wso2sp/4.2.0'
+  }
+  elsif $::osfamily == 'debian' {
+    $sp_package = 'wso2sp-linux-installer-x64-4.2.0.deb'
+    $installer_provider = 'dpkg'
+    $install_path = '/usr/lib/wso2/wso2sp/4.2.0'
+  }
+
+  # Create wso2 group
+  group { $user_group:
+    ensure => present,
+    gid    => $user_group_id,
+    system => true,
+  }
+
+  # Create wso2 user
+  user { $user:
+    ensure => present,
+    uid    => $user_id,
+    gid    => $user_group_id,
+    home   => "/home/${user}",
+    system => true,
+  }
+  # Ensure the installation directory is available
+  file { "/opt/${product_name}":
+    ensure => 'directory',
+    owner  => $user,
+    group  => $user_group,
+  }
+
+  # Copy the installer to the directory
+  file { "/opt/${product_name}/${sp_package}":
+    owner  => $user,
+    group  => $user_group,
+    mode   => '0644',
+    source => "puppet:///modules/${module_name}/${sp_package}",
+  }
+
+  # Install WSO2 API Manager
+  package { $product_name:
+    ensure   => installed,
+    provider => $installer_provider,
+    source   => "/opt/${product_name}/${sp_package}"
+  }
+
+  # Change the ownership of the installation directory to wso2 user & group
+  file { $install_path:
+    ensure  => directory,
+    owner   => $user,
+    group   => $user_group,
+    require => [ User[$user], Group[$user_group]],
+    recurse => true
+  }
+
+  # Copy deployment.yaml to the installed directory
+  file { "${install_path}/${deployment_yaml_template}":
+    ensure  => file,
+    owner   => $user,
+    group   => $user_group,
+    mode    => '0644',
+    content => template("${module_name}/carbon-home/${deployment_yaml_template}.erb")
+  }
+
+  # Copy dashboard.sh to installed directory
+  file { "${install_path}/${start_script_template}":
+    ensure  => file,
+    owner   => $user,
+    group   => $user_group,
+    mode    => '0754',
+    content => template("${module_name}/carbon-home/${start_script_template}.erb")
+  }
+
+  # Copy the unit file required to deploy the server as a service
+  file { "/etc/systemd/system/${service_name}.service":
+    ensure  => present,
+    owner   => root,
+    group   => root,
+    mode    => '0754',
+    content => template("${module_name}/${service_name}.service.erb"),
+  }
+
+  /*
+    Following script can be used to copy file to a given location.
+    This will copy some_file to install_path -> repository.
+    Note: Ensure
+    that file is available in modules -> sp_dashboard -> files
+  */
+  # file { "${install_path}/repository/some_file":
+  #   owner  => $user,
+  #   group  => $user_group,
+  #   mode   => '0644',
+  #   source => "puppet:///modules/${module_name}/some_file",
+  # }
+}

--- a/modules/sp_editor/manifests/init.pp
+++ b/modules/sp_editor/manifests/init.pp
@@ -27,6 +27,46 @@ class sp_editor (
   $start_script_template = $sp_editor::params::start_script_template,
   $deployment_yaml_template = $sp_editor::params::deployment_yaml_template,
   $jre_version = $sp_editor::params::jre_version,
+
+  # -------- deployment.yaml configs --------
+
+  # listenerConfigurations
+  $default_host = $sp_editor::params::default_host,
+
+  $msf4j_host = $sp_editor::params::msf4j_host,
+  $msf4j_keystore_file = $sp_editor::params::msf4j_keystore_file,
+  $msf4j_keystore_password = $sp_editor::params::msf4j_keystore_password,
+  $msf4j_cert_pass = $sp_editor::params::msf4j_cert_pass,
+
+  # Configuration used for the databridge communication
+  $databridge_keystore_location = $sp_editor::params::databridge_keystore_location,
+  $databridge_keystore_password = $sp_editor::params::databridge_keystore_password,
+  $binary_data_receiver_hostname = $sp_editor::params::binary_data_receiver_hostname,
+
+  # Configuration of the Data Agents - to publish events through databridge
+  $thrift_agent_trust_store = $sp_editor::params::thrift_agent_trust_store,
+  $thrift_agent_trust_store_password = $sp_editor::params::thrift_agent_trust_store_password,
+  $binary_agent_trust_store = $sp_editor::params::binary_agent_trust_store,
+  $binary_agent_trust_store_password = $sp_editor::params::binary_agent_trust_store_password,
+
+  # Secure Vault Configuration
+  $securevault_private_key_alias = $sp_editor::params::securevault_private_key_alias,
+  $securevault_keystore = $sp_editor::params::securevault_keystore,
+  $securevault_secret_properties_file = $sp_editor::params::securevault_secret_properties_file,
+  $securevault_master_key_reader_file = $sp_editor::params::securevault_master_key_reader_file,
+
+  # Datasource Configurations
+  $carbon_db_url = $sp_editor::params::carbon_db_url,
+  $carbon_db_username = $sp_editor::params::carbon_db_username,
+  $carbon_db_password = $sp_editor::params::carbon_db_password,
+  $carbon_db_driver = $sp_editor::params::carbon_db_driver,
+
+  # Cluster Configuration
+  $cluster_enabled = $sp_editor::params::cluster_enabled,
+
+  #Authentication Configurations
+  $rest_api_auth_enable = $sp_editor::params::rest_api_auth_enable,
+
 )
 inherits sp_editor::params {
 

--- a/modules/sp_editor/manifests/init.pp
+++ b/modules/sp_editor/manifests/init.pp
@@ -111,7 +111,7 @@ inherits sp_editor::params {
     source => "puppet:///modules/${module_name}/${sp_package}",
   }
 
-  # Install WSO2 API Manager
+  # Install WSO2 Stream Processor
   package { $product_name:
     ensure   => installed,
     provider => $installer_provider,

--- a/modules/sp_editor/manifests/params.pp
+++ b/modules/sp_editor/manifests/params.pp
@@ -69,9 +69,4 @@ class sp_editor::params {
 
   #Authentication Configurations
   $rest_api_auth_enable = 'false'
-
-
-
-
-
 }

--- a/modules/sp_editor/manifests/params.pp
+++ b/modules/sp_editor/manifests/params.pp
@@ -30,4 +30,48 @@ class sp_editor::params {
   # Define the template
   $start_script_template = "bin/${product_profile}.sh"
   $deployment_yaml_template = "conf/${product_profile}/deployment.yaml"
+
+  # -------- deployment.yaml configs --------
+
+  # listenerConfigurations
+  $default_host = '0.0.0.0'
+
+  $msf4j_host = '0.0.0.0'
+  $msf4j_keystore_file = '${carbon.home}/resources/security/wso2carbon.jks'
+  $msf4j_keystore_password = 'wso2carbon'
+  $msf4j_cert_pass = 'wso2carbon'
+
+  # Configuration used for the databridge communication
+  $databridge_keystore_location = '${sys:carbon.home}/resources/security/wso2carbon.jks'
+  $databridge_keystore_password = 'wso2carbon'
+  $binary_data_receiver_hostname = '0.0.0.0'
+
+  # Configuration of the Data Agents - to publish events through databridge
+  $thrift_agent_trust_store = '${sys:carbon.home}/resources/security/client-truststore.jks'
+  $thrift_agent_trust_store_password = 'wso2carbon'
+  $binary_agent_trust_store = '${sys:carbon.home}/resources/security/client-truststore.jks'
+  $binary_agent_trust_store_password = 'wso2carbon'
+
+  # Secure Vault Configuration
+  $securevault_private_key_alias = 'wso2carbon'
+  $securevault_keystore = '${sys:carbon.home}/resources/security/securevault.jks'
+  $securevault_secret_properties_file = '${sys:carbon.home}/conf/${sys:wso2.runtime}/secrets.properties'
+  $securevault_master_key_reader_file = '${sys:carbon.home}/conf/${sys:wso2.runtime}/master-keys.yaml'
+
+  # Datasource Configurations
+  $carbon_db_url = 'jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/WSO2_CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000'
+  $carbon_db_username = 'wso2carbon'
+  $carbon_db_password = 'wso2carbon'
+  $carbon_db_driver = 'org.h2.Driver'
+
+  # Cluster Configuration
+  $cluster_enabled = 'false'
+
+  #Authentication Configurations
+  $rest_api_auth_enable = 'false'
+
+
+
+
+
 }

--- a/modules/sp_editor/manifests/params.pp
+++ b/modules/sp_editor/manifests/params.pp
@@ -1,0 +1,33 @@
+# ----------------------------------------------------------------------------
+#  Copyright (c) 2018 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# ----------------------------------------------------------------------------
+
+# Claas sp_editor::params
+# This class includes all the necessary parameters
+class sp_editor::params {
+  $user = 'wso2carbon'
+  $user_id = 802
+  $user_group = 'wso2'
+  $user_home = '/home/$user'
+  $user_group_id = 802
+  $product_name = 'wso2sp'
+  $product_profile = 'editor'
+  $service_name = "${product_name}-${product_profile}"
+  $jre_version = 'jre1.8.0_172'
+
+  # Define the template
+  $start_script_template = "bin/${product_profile}.sh"
+  $deployment_yaml_template = "conf/${product_profile}/deployment.yaml"
+}

--- a/modules/sp_editor/manifests/startserver.pp
+++ b/modules/sp_editor/manifests/startserver.pp
@@ -1,0 +1,28 @@
+# ----------------------------------------------------------------------------
+#  Copyright (c) 2018 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# ----------------------------------------------------------------------------
+
+# Class sp_editor::startserver
+#
+class sp_editor::startserver (
+  $service_name = $sp_editor::params::service_name
+)
+  inherits sp_editor::params {
+
+  service { $service_name:
+    ensure => running,
+    enable => true
+  }
+}

--- a/modules/sp_editor/templates/carbon-home/bin/editor.sh.erb
+++ b/modules/sp_editor/templates/carbon-home/bin/editor.sh.erb
@@ -1,0 +1,67 @@
+#!/bin/sh
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+export JAVA_HOME="<%=@install_path%>/jre/<%=@jre_version%>"
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+             JAVA_VERSION="CurrentJDK"
+           else
+             echo "Using Java version: $JAVA_VERSION"
+           fi
+           if [ -z "$JAVA_HOME" ] ; then
+             JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+           fi
+           ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+[ -z "$RUNTIME_HOME" ] && RUNTIME_HOME=`cd "$PRGDIR/../wso2/editor" ; pwd`
+
+###########################################################################
+NAME=start-editor
+# Daemon name, where is the actual executable
+EDITOR_INIT_SCRIPT="$CARBON_HOME/wso2/editor/bin/carbon.sh"
+
+# If the daemon is not there, then exit.
+
+$EDITOR_INIT_SCRIPT $*
+exit;

--- a/modules/sp_editor/templates/carbon-home/conf/editor/deployment.yaml.erb
+++ b/modules/sp_editor/templates/carbon-home/conf/editor/deployment.yaml.erb
@@ -1,0 +1,286 @@
+################################################################################
+#   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved
+#
+#   Licensed under the Apache License, Version 2.0 (the \"License\");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an \"AS IS\" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+################################################################################
+
+  # Carbon Configuration Parameters
+wso2.carbon:
+    # value to uniquely identify a server
+  id: wso2-sp
+    # server name
+  name: WSO2 Stream Processor
+    # ports used by this server
+  ports:
+      # port offset
+    offset: 3
+
+wso2.transport.http:
+  transportProperties:
+    -
+      name: "server.bootstrap.socket.timeout"
+      value: 60
+    -
+      name: "client.bootstrap.socket.timeout"
+      value: 60
+    -
+      name: "latency.metrics.enabled"
+      value: true
+
+  listenerConfigurations:
+    -
+      id: "default"
+      host: "0.0.0.0"
+      port: 9390
+    -
+      id: "msf4j-https"
+      host: "0.0.0.0"
+      port: 9743
+      scheme: https
+      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
+      keyStorePassword: wso2carbon
+      certPass: wso2carbon
+
+  senderConfigurations:
+    -
+      id: "http-sender"
+
+  # Configuration used for the databridge communication
+databridge.config:
+    # No of worker threads to consume events
+    # THIS IS A MANDATORY FIELD
+  workerThreads: 10
+    # Maximum amount of messages that can be queued internally in MB
+    # THIS IS A MANDATORY FIELD
+  maxEventBufferCapacity: 10000000
+    # Queue size; the maximum number of events that can be stored in the queue
+    # THIS IS A MANDATORY FIELD
+  eventBufferSize: 2000
+    # Keystore file path
+    # THIS IS A MANDATORY FIELD
+  keyStoreLocation : ${sys:carbon.home}/resources/security/wso2carbon.jks
+    # Keystore password
+    # THIS IS A MANDATORY FIELD
+  keyStorePassword : wso2carbon
+    # Session Timeout value in mins
+    # THIS IS A MANDATORY FIELD
+  clientTimeoutMin: 30
+    # Data receiver configurations
+    # THIS IS A MANDATORY FIELD
+  dataReceivers:
+  -
+      # Data receiver configuration
+    dataReceiver:
+        # Data receiver type
+        # THIS IS A MANDATORY FIELD
+      type: Thrift
+        # Data receiver properties
+      properties:
+        tcpPort: '7611'
+        sslPort: '7711'
+
+  -
+      # Data receiver configuration
+    dataReceiver:
+        # Data receiver type
+        # THIS IS A MANDATORY FIELD
+      type: Binary
+        # Data receiver properties
+      properties:
+        tcpPort: '9611'
+        sslPort: '9711'
+        tcpReceiverThreadPoolSize: '100'
+        sslReceiverThreadPoolSize: '100'
+        hostName: 0.0.0.0
+
+  # Configuration of the Data Agents - to publish events through databridge
+data.agent.config:
+    # Data agent configurations
+    # THIS IS A MANDATORY FIELD
+  agents:
+  -
+      # Data agent configuration
+    agentConfiguration:
+        # Data agent name
+        # THIS IS A MANDATORY FIELD
+      name: Thrift
+        # Data endpoint class
+        # THIS IS A MANDATORY FIELD
+      dataEndpointClass: org.wso2.carbon.databridge.agent.endpoint.thrift.ThriftDataEndpoint
+        # Data publisher strategy
+      publishingStrategy: async
+        # Trust store path
+      trustStorePath: '${sys:carbon.home}/resources/security/client-truststore.jks'
+        # Trust store password
+      trustStorePassword: 'wso2carbon'
+        # Queue Size
+      queueSize: 32768
+        # Batch Size
+      batchSize: 200
+        # Core pool size
+      corePoolSize: 1
+        # Socket timeout in milliseconds
+      socketTimeoutMS: 30000
+        # Maximum pool size
+      maxPoolSize: 1
+        # Keep alive time in pool
+      keepAliveTimeInPool: 20
+        # Reconnection interval
+      reconnectionInterval: 30
+        # Max transport pool size
+      maxTransportPoolSize: 250
+        # Max idle connections
+      maxIdleConnections: 250
+        # Eviction time interval
+      evictionTimePeriod: 5500
+        # Min idle time in pool
+      minIdleTimeInPool: 5000
+        # Secure max transport pool size
+      secureMaxTransportPoolSize: 250
+        # Secure max idle connections
+      secureMaxIdleConnections: 250
+        # secure eviction time period
+      secureEvictionTimePeriod: 5500
+        # Secure min idle time in pool
+      secureMinIdleTimeInPool: 5000
+        # SSL enabled protocols
+      sslEnabledProtocols: TLSv1.1,TLSv1.2
+        # Ciphers
+      ciphers: TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
+  -
+      # Data agent configuration
+    agentConfiguration:
+        # Data agent name
+        # THIS IS A MANDATORY FIELD
+      name: Binary
+        # Data endpoint class
+        # THIS IS A MANDATORY FIELD
+      dataEndpointClass: org.wso2.carbon.databridge.agent.endpoint.binary.BinaryDataEndpoint
+        # Data publisher strategy
+      publishingStrategy: async
+        # Trust store path
+      trustStorePath: '${sys:carbon.home}/resources/security/client-truststore.jks'
+        # Trust store password
+      trustStorePassword: 'wso2carbon'
+        # Queue Size
+      queueSize: 32768
+        # Batch Size
+      batchSize: 200
+        # Core pool size
+      corePoolSize: 1
+        # Socket timeout in milliseconds
+      socketTimeoutMS: 30000
+        # Maximum pool size
+      maxPoolSize: 1
+        # Keep alive time in pool
+      keepAliveTimeInPool: 20
+        # Reconnection interval
+      reconnectionInterval: 30
+        # Max transport pool size
+      maxTransportPoolSize: 250
+        # Max idle connections
+      maxIdleConnections: 250
+        # Eviction time interval
+      evictionTimePeriod: 5500
+        # Min idle time in pool
+      minIdleTimeInPool: 5000
+        # Secure max transport pool size
+      secureMaxTransportPoolSize: 250
+        # Secure max idle connections
+      secureMaxIdleConnections: 250
+        # secure eviction time period
+      secureEvictionTimePeriod: 5500
+        # Secure min idle time in pool
+      secureMinIdleTimeInPool: 5000
+        # SSL enabled protocols
+      sslEnabledProtocols: TLSv1.1,TLSv1.2
+        # Ciphers
+      ciphers: TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
+
+  # Deployment configuration parameters
+wso2.artifact.deployment:
+    # Scheduler update interval
+  updateInterval: 2
+
+  # Periodic Persistence Configuration
+state.persistence:
+  enabled: false
+  intervalInMin: 1
+  revisionsToKeep: 2
+  persistenceStore: org.wso2.carbon.stream.processor.core.persistence.FileSystemPersistenceStore
+  config:
+    location: siddhi-app-persistence
+
+  # Secure Vault Configuration
+wso2.securevault:
+  secretRepository:
+    type: org.wso2.carbon.secvault.repository.DefaultSecretRepository
+    parameters:
+      privateKeyAlias: wso2carbon
+      keystoreLocation: ${sys:carbon.home}/resources/security/securevault.jks
+      secretPropertiesFile: ${sys:carbon.home}/conf/${sys:wso2.runtime}/secrets.properties
+  masterKeyReader:
+    type: org.wso2.carbon.secvault.reader.DefaultMasterKeyReader
+    parameters:
+      masterKeyReaderFile: ${sys:carbon.home}/conf/${sys:wso2.runtime}/master-keys.yaml
+
+  # Datasource Configurations
+wso2.datasources:
+  dataSources:
+  - name: WSO2_CARBON_DB
+    description: The datasource used for registry and user manager
+    definition:
+      type: RDBMS
+      configuration:
+        jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/WSO2_CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000'
+        username: wso2carbon
+        password: wso2carbon
+        driverClassName: org.h2.Driver
+        maxPoolSize: 50
+        idleTimeout: 60000
+        connectionTestQuery: SELECT 1
+        validationTimeout: 30000
+        isAutoCommit: false
+
+  - name: Message_Tracing_DB
+    description: "The datasource used for message tracer to store span information."
+    jndiConfig:
+      name: jdbc/Message_Tracing_DB
+    definition:
+      type: RDBMS
+      configuration:
+        jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/dashboard/database/MESSAGE_TRACING_DB;AUTO_SERVER=TRUE'
+        username: wso2carbon
+        password: wso2carbon
+        driverClassName: org.h2.Driver
+        maxPoolSize: 50
+        idleTimeout: 60000
+        connectionTestQuery: SELECT 1
+        validationTimeout: 30000
+        isAutoCommit: false
+
+  # Cluster Configuration
+cluster.config:
+  enabled: false
+  groupId:  sp
+  coordinationStrategyClass: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
+  strategyConfig:
+    datasource: WSO2_CARBON_DB
+    heartbeatInterval: 1000
+    heartbeatMaxRetry: 2
+    eventPollingInterval: 1000
+
+    #Authentication Configurations: Authentication is disabled in editor profile
+auth.configs:
+  restAPIAuthConfigs:
+    authEnable: false

--- a/modules/sp_editor/templates/carbon-home/conf/editor/deployment.yaml.erb
+++ b/modules/sp_editor/templates/carbon-home/conf/editor/deployment.yaml.erb
@@ -40,16 +40,16 @@ wso2.transport.http:
   listenerConfigurations:
     -
       id: "default"
-      host: "0.0.0.0"
+      host: "<%= @default_host %>"
       port: 9390
     -
       id: "msf4j-https"
-      host: "0.0.0.0"
+      host: "<%= @msf4j_host %>"
       port: 9743
       scheme: https
-      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
-      keyStorePassword: wso2carbon
-      certPass: wso2carbon
+      keyStoreFile: "<%= @msf4j_keystore_file %>"
+      keyStorePassword: <%= @msf4j_keystore_password %>
+      certPass: <%= @msf4j_cert_pass %>
 
   senderConfigurations:
     -
@@ -68,10 +68,10 @@ databridge.config:
   eventBufferSize: 2000
     # Keystore file path
     # THIS IS A MANDATORY FIELD
-  keyStoreLocation : ${sys:carbon.home}/resources/security/wso2carbon.jks
+  keyStoreLocation : <%= @databridge_keystore_location %>
     # Keystore password
     # THIS IS A MANDATORY FIELD
-  keyStorePassword : wso2carbon
+  keyStorePassword : <%= @databridge_keystore_password %>
     # Session Timeout value in mins
     # THIS IS A MANDATORY FIELD
   clientTimeoutMin: 30
@@ -101,7 +101,7 @@ databridge.config:
         sslPort: '9711'
         tcpReceiverThreadPoolSize: '100'
         sslReceiverThreadPoolSize: '100'
-        hostName: 0.0.0.0
+        hostName: <%= @binary_data_receiver_hostname %>
 
   # Configuration of the Data Agents - to publish events through databridge
 data.agent.config:
@@ -120,9 +120,9 @@ data.agent.config:
         # Data publisher strategy
       publishingStrategy: async
         # Trust store path
-      trustStorePath: '${sys:carbon.home}/resources/security/client-truststore.jks'
+      trustStorePath: '<%= @thrift_agent_trust_store %>'
         # Trust store password
-      trustStorePassword: 'wso2carbon'
+      trustStorePassword: '<%= @thrift_agent_trust_store_password %>'
         # Queue Size
       queueSize: 32768
         # Batch Size
@@ -169,9 +169,9 @@ data.agent.config:
         # Data publisher strategy
       publishingStrategy: async
         # Trust store path
-      trustStorePath: '${sys:carbon.home}/resources/security/client-truststore.jks'
+      trustStorePath: '<%= @binary_agent_trust_store %>'
         # Trust store password
-      trustStorePassword: 'wso2carbon'
+      trustStorePassword: '<%= @binary_agent_trust_store_password %>'
         # Queue Size
       queueSize: 32768
         # Batch Size
@@ -226,13 +226,13 @@ wso2.securevault:
   secretRepository:
     type: org.wso2.carbon.secvault.repository.DefaultSecretRepository
     parameters:
-      privateKeyAlias: wso2carbon
-      keystoreLocation: ${sys:carbon.home}/resources/security/securevault.jks
-      secretPropertiesFile: ${sys:carbon.home}/conf/${sys:wso2.runtime}/secrets.properties
+      privateKeyAlias: <%= @securevault_private_key_alias %>
+      keystoreLocation: <%= @securevault_keystore %>
+      secretPropertiesFile: <%= @securevault_secret_properties_file %>
   masterKeyReader:
     type: org.wso2.carbon.secvault.reader.DefaultMasterKeyReader
     parameters:
-      masterKeyReaderFile: ${sys:carbon.home}/conf/${sys:wso2.runtime}/master-keys.yaml
+      masterKeyReaderFile: <%= @securevault_master_key_reader_file %>
 
   # Datasource Configurations
 wso2.datasources:
@@ -242,10 +242,10 @@ wso2.datasources:
     definition:
       type: RDBMS
       configuration:
-        jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/WSO2_CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000'
-        username: wso2carbon
-        password: wso2carbon
-        driverClassName: org.h2.Driver
+        jdbcUrl: '<%= @carbon_db_url %>'
+        username: <%= @carbon_db_username %>
+        password: <%= @carbon_db_password %>
+        driverClassName: <%= @carbon_db_driver %>
         maxPoolSize: 50
         idleTimeout: 60000
         connectionTestQuery: SELECT 1
@@ -271,7 +271,7 @@ wso2.datasources:
 
   # Cluster Configuration
 cluster.config:
-  enabled: false
+  enabled: <%= @cluster_enabled %>
   groupId:  sp
   coordinationStrategyClass: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
   strategyConfig:
@@ -283,4 +283,4 @@ cluster.config:
     #Authentication Configurations: Authentication is disabled in editor profile
 auth.configs:
   restAPIAuthConfigs:
-    authEnable: false
+    authEnable: <%= @rest_api_auth_enable %>

--- a/modules/sp_editor/templates/wso2sp-editor.service.erb
+++ b/modules/sp_editor/templates/wso2sp-editor.service.erb
@@ -1,0 +1,19 @@
+[Unit]
+Description=WSO2 Stream Processor - Editor
+After=network.target
+
+[Service]
+ExecStart=<%=@install_path%>/bin/<%=@product_profile%>.sh start
+ExecStop=<%=@install_path%>/bin/<%=@product_profile%>.sh stop
+ExecRestart=<%=@install_path%>/bin/<%=@product_profile%>.sh restart
+PIDFile=<%=@install_path%>/wso2/<%=@product_profile%>/runtime.pid
+User=<%=@user%>
+Group=<%=@user_group%>
+Type=forking
+Restart=on-failure
+RestartSec=5
+StartLimitInterval=60s
+StartLimitBurst=3
+
+[Install]
+WantedBy=multi-user.target

--- a/modules/sp_manager/manifests/custom.pp
+++ b/modules/sp_manager/manifests/custom.pp
@@ -1,0 +1,21 @@
+# ----------------------------------------------------------------------------
+#  Copyright (c) 2018 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# ----------------------------------------------------------------------------
+
+# Class: sp_manager::custom
+# This class is reserved to run custom user code before starting the server.
+class sp_manager::custom {
+  # Resources
+}

--- a/modules/sp_manager/manifests/init.pp
+++ b/modules/sp_manager/manifests/init.pp
@@ -17,16 +17,52 @@
 # Class: sp_manager
 # Init class of stream processor all in one profile
 class sp_manager (
-  $user                 = $sp_manager::params::user,
-  $user_id              = $sp_manager::params::user_id,
-  $user_group           = $sp_manager::params::user_group,
-  $user_group_id        = $sp_manager::params::user_group_id,
-  $product_name         = $sp_manager::params::product_name,
-  $service_name         = $sp_manager::params::service_name,
+  $user = $sp_manager::params::user,
+  $user_id = $sp_manager::params::user_id,
+  $user_group = $sp_manager::params::user_group,
+  $user_group_id = $sp_manager::params::user_group_id,
+  $product_name = $sp_manager::params::product_name,
+  $service_name = $sp_manager::params::service_name,
   $service_profile = $sp_manager::params::service_profile,
   $start_script_template = $sp_manager::params::start_script_template,
   $deployment_yaml_template = $sp_manager::params::deployment_yaml_template,
   $jre_version = $sp_manager::params::jre_version,
+
+  # -------- deployment.yaml configs --------
+
+  # listenerConfigurations
+  $default_host = $sp_manager::params::default_host,
+
+  $msf4j_host = $sp_manager::params::msf4j_host,
+  $msf4j_keystore_file = $sp_manager::params::msf4j_keystore_file,
+  $msf4j_keystore_password = $sp_manager::params::msf4j_keystore_password,
+  $msf4j_cert_pass = $sp_manager::params::msf4j_cert_pass,
+
+  # Configuration used for the databridge communication
+  $databridge_keystore_location = $sp_manager::params::databridge_keystore_location,
+  $databridge_keystore_password = $sp_manager::params::databridge_keystore_password,
+  $binary_data_receiver_hostname = $sp_manager::params::binary_data_receiver_hostname,
+
+  # Configuration of the Data Agents - to publish events through databridge
+  $thrift_agent_trust_store = $sp_manager::params::thrift_agent_trust_store,
+  $thrift_agent_trust_store_password = $sp_manager::params::thrift_agent_trust_store_password,
+  $binary_agent_trust_store = $sp_manager::params::binary_agent_trust_store,
+  $binary_agent_trust_store_password = $sp_manager::params::binary_agent_trust_store_password,
+
+  # Secure Vault Configuration
+  $securevault_private_key_alias = $sp_manager::params::securevault_private_key_alias,
+  $securevault_keystore = $sp_manager::params::securevault_keystore,
+  $securevault_secret_properties_file = $sp_manager::params::securevault_secret_properties_file,
+  $securevault_master_key_reader_file = $sp_manager::params::securevault_master_key_reader_file,
+
+  # Datasource Configurations
+  $mgt_db_rul = $sp_manager::params::mgt_db_rul,
+  $mgt_db_username = $sp_manager::params::mgt_db_username,
+  $mgt_db_password = $sp_manager::params::mgt_db_password,
+  $mgt_db_dirver = $sp_manager::params::mgt_db_dirver,
+
+  # Cluster Configuration
+  $cluster_enabled = $sp_manager::params::cluster_enabled,
 )
 inherits sp_manager::params {
 

--- a/modules/sp_manager/manifests/init.pp
+++ b/modules/sp_manager/manifests/init.pp
@@ -107,7 +107,7 @@ inherits sp_manager::params {
     source => "puppet:///modules/${module_name}/${sp_package}",
   }
 
-  # Install WSO2 API Manager
+  # Install WSO2 Stream Processor
   package { $product_name:
     ensure   => installed,
     provider => $installer_provider,

--- a/modules/sp_manager/manifests/init.pp
+++ b/modules/sp_manager/manifests/init.pp
@@ -1,0 +1,129 @@
+# ----------------------------------------------------------------------------
+#  Copyright (c) 2018 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# ----------------------------------------------------------------------------
+
+# Class: sp_manager
+# Init class of stream processor all in one profile
+class sp_manager (
+  $user                 = $sp_manager::params::user,
+  $user_id              = $sp_manager::params::user_id,
+  $user_group           = $sp_manager::params::user_group,
+  $user_group_id        = $sp_manager::params::user_group_id,
+  $product_name         = $sp_manager::params::product_name,
+  $service_name         = $sp_manager::params::service_name,
+  $service_profile = $sp_manager::params::service_profile,
+  $start_script_template = $sp_manager::params::start_script_template,
+  $deployment_yaml_template = $sp_manager::params::deployment_yaml_template,
+  $jre_version = $sp_manager::params::jre_version,
+)
+inherits sp_manager::params {
+
+  if $::osfamily == 'redhat' {
+    $sp_package = 'wso2sp-linux-installer-x64-4.2.0.rpm'
+    $installer_provider = 'rpm'
+    $install_path = '/usr/lib64/wso2/wso2sp/4.2.0'
+  }
+  elsif $::osfamily == 'debian' {
+    $sp_package = 'wso2sp-linux-installer-x64-4.2.0.deb'
+    $installer_provider = 'dpkg'
+    $install_path = '/usr/lib/wso2/wso2sp/4.2.0'
+  }
+
+  # Create wso2 group
+  group { $user_group:
+    ensure => present,
+    gid    => $user_group_id,
+    system => true,
+  }
+
+  # Create wso2 user
+  user { $user:
+    ensure => present,
+    uid    => $user_id,
+    gid    => $user_group_id,
+    home   => "/home/${user}",
+    system => true,
+  }
+  # Ensure the installation directory is available
+  file { "/opt/${product_name}":
+    ensure => 'directory',
+    owner  => $user,
+    group  => $user_group,
+  }
+
+  # Copy the installer to the directory
+  file { "/opt/${product_name}/${sp_package}":
+    owner  => $user,
+    group  => $user_group,
+    mode   => '0644',
+    source => "puppet:///modules/${module_name}/${sp_package}",
+  }
+
+  # Install WSO2 API Manager
+  package { $product_name:
+    ensure   => installed,
+    provider => $installer_provider,
+    source   => "/opt/${product_name}/${sp_package}"
+  }
+
+  # Change the ownership of the installation directory to wso2 user & group
+  file { $install_path:
+    ensure  => directory,
+    owner   => $user,
+    group   => $user_group,
+    require => [ User[$user], Group[$user_group]],
+    recurse => true
+  }
+
+  # Copy deployment.yaml to the installed directory
+  file { "${install_path}/${deployment_yaml_template}":
+    ensure  => file,
+    owner   => $user,
+    group   => $user_group,
+    mode    => '0644',
+    content => template("${module_name}/carbon-home/${deployment_yaml_template}.erb")
+  }
+
+  # Copy dashboard.sh to installed directory
+  file { "${install_path}/${start_script_template}":
+    ensure  => file,
+    owner   => $user,
+    group   => $user_group,
+    mode    => '0754',
+    content => template("${module_name}/carbon-home/${start_script_template}.erb")
+  }
+
+  # Copy the unit file required to deploy the server as a service
+  file { "/etc/systemd/system/${service_name}.service":
+    ensure  => present,
+    owner   => root,
+    group   => root,
+    mode    => '0754',
+    content => template("${module_name}/${service_name}.service.erb"),
+  }
+
+  /*
+    Following script can be used to copy file to a given location.
+    This will copy some_file to install_path -> repository.
+    Note: Ensure
+    that file is available in modules -> sp_dashboard -> files
+  */
+  # file { "${install_path}/repository/some_file":
+  #   owner  => $user,
+  #   group  => $user_group,
+  #   mode   => '0644',
+  #   source => "puppet:///modules/${module_name}/some_file",
+  # }
+}

--- a/modules/sp_manager/manifests/init.pp
+++ b/modules/sp_manager/manifests/init.pp
@@ -56,7 +56,7 @@ class sp_manager (
   $securevault_master_key_reader_file = $sp_manager::params::securevault_master_key_reader_file,
 
   # Datasource Configurations
-  $mgt_db_rul = $sp_manager::params::mgt_db_rul,
+  $mgt_db_url = $sp_manager::params::mgt_db_url,
   $mgt_db_username = $sp_manager::params::mgt_db_username,
   $mgt_db_password = $sp_manager::params::mgt_db_password,
   $mgt_db_dirver = $sp_manager::params::mgt_db_dirver,

--- a/modules/sp_manager/manifests/params.pp
+++ b/modules/sp_manager/manifests/params.pp
@@ -1,0 +1,33 @@
+# ----------------------------------------------------------------------------
+#  Copyright (c) 2018 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# ----------------------------------------------------------------------------
+
+# Claas sp_manager::params
+# This class includes all the necessary parameters
+class sp_manager::params {
+  $user = 'wso2carbon'
+  $user_id = 802
+  $user_group = 'wso2'
+  $user_home = '/home/$user'
+  $user_group_id = 802
+  $product_name = 'wso2sp'
+  $product_profile = 'manager'
+  $service_name = "${product_name}-${product_profile}"
+  $jre_version = 'jre1.8.0_172'
+
+  # Define the template
+  $start_script_template = "bin/${product_profile}.sh"
+  $deployment_yaml_template = "conf/${product_profile}/deployment.yaml"
+}

--- a/modules/sp_manager/manifests/params.pp
+++ b/modules/sp_manager/manifests/params.pp
@@ -59,7 +59,7 @@ class sp_manager::params {
   $securevault_master_key_reader_file = '${sys:carbon.home}/conf/${sys:wso2.runtime}/master-keys.yaml'
 
   # Datasource Configurations
-  $mgt_db_rul = 'jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/SP_MGT_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000'
+  $mgt_db_url = 'jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/SP_MGT_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000'
   $mgt_db_username = 'wso2carbon'
   $mgt_db_password = 'wso2carbon'
   $mgt_db_dirver = 'org.h2.Driver'

--- a/modules/sp_manager/manifests/params.pp
+++ b/modules/sp_manager/manifests/params.pp
@@ -30,4 +30,57 @@ class sp_manager::params {
   # Define the template
   $start_script_template = "bin/${product_profile}.sh"
   $deployment_yaml_template = "conf/${product_profile}/deployment.yaml"
+
+  # -------- deployment.yaml configs --------
+
+  # listenerConfigurations
+  $default_host = '0.0.0.0'
+
+  $msf4j_host = '0.0.0.0'
+  $msf4j_keystore_file = '${carbon.home}/resources/security/wso2carbon.jks'
+  $msf4j_keystore_password = 'wso2carbon'
+  $msf4j_cert_pass = 'wso2carbon'
+
+  # Configuration used for the databridge communication
+  $databridge_keystore_location = '${sys:carbon.home}/resources/security/wso2carbon.jks'
+  $databridge_keystore_password = 'wso2carbon'
+  $binary_data_receiver_hostname = '0.0.0.0'
+
+  # Configuration of the Data Agents - to publish events through databridge
+  $thrift_agent_trust_store = '${sys:carbon.home}/resources/security/client-truststore.jks'
+  $thrift_agent_trust_store_password = 'wso2carbon'
+  $binary_agent_trust_store = '${sys:carbon.home}/resources/security/client-truststore.jks'
+  $binary_agent_trust_store_password = 'wso2carbon'
+
+  # Secure Vault Configuration
+  $securevault_private_key_alias = 'wso2carbon'
+  $securevault_keystore = '${sys:carbon.home}/resources/security/securevault.jks'
+  $securevault_secret_properties_file = '${sys:carbon.home}/conf/${sys:wso2.runtime}/secrets.properties'
+  $securevault_master_key_reader_file = '${sys:carbon.home}/conf/${sys:wso2.runtime}/master-keys.yaml'
+
+  # Datasource Configurations
+  $mgt_db_rul = 'jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/SP_MGT_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000'
+  $mgt_db_username = 'wso2carbon'
+  $mgt_db_password = 'wso2carbon'
+  $mgt_db_dirver = 'org.h2.Driver'
+
+  # Cluster Configuration
+  $cluster_enabled = 'false'
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 }

--- a/modules/sp_manager/manifests/params.pp
+++ b/modules/sp_manager/manifests/params.pp
@@ -66,21 +66,4 @@ class sp_manager::params {
 
   # Cluster Configuration
   $cluster_enabled = 'false'
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 }

--- a/modules/sp_manager/manifests/startserver.pp
+++ b/modules/sp_manager/manifests/startserver.pp
@@ -1,0 +1,28 @@
+# ----------------------------------------------------------------------------
+#  Copyright (c) 2018 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# ----------------------------------------------------------------------------
+
+# Class sp_manager::startserver
+#
+class sp_manager::startserver (
+  $service_name = $sp_manager::params::service_name
+)
+  inherits sp_manager::params {
+
+  service { $service_name:
+    ensure => running,
+    enable => true
+  }
+}

--- a/modules/sp_manager/templates/carbon-home/bin/manager.sh.erb
+++ b/modules/sp_manager/templates/carbon-home/bin/manager.sh.erb
@@ -1,0 +1,68 @@
+#!/bin/sh
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+export JAVA_HOME="<%=@install_path%>/jre/<%=@jre_version%>"
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+             JAVA_VERSION="CurrentJDK"
+           else
+             echo "Using Java version: $JAVA_VERSION"
+           fi
+           if [ -z "$JAVA_HOME" ] ; then
+             JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+           fi
+           ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+[ -z "$RUNTIME_HOME" ] && RUNTIME_HOME=`cd "$PRGDIR/../wso2/manager" ; pwd`
+
+###########################################################################
+NAME=start-manager
+# Daemon name, where is the actual executable
+
+MANAGER_INIT_SCRIPT="$CARBON_HOME/wso2/manager/bin/carbon.sh"
+
+# If the daemon is not there, then exit.
+
+$MANAGER_INIT_SCRIPT $*
+exit;

--- a/modules/sp_manager/templates/carbon-home/conf/manager/deployment.yaml.erb
+++ b/modules/sp_manager/templates/carbon-home/conf/manager/deployment.yaml.erb
@@ -1,0 +1,296 @@
+################################################################################
+#   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved
+#
+#   Licensed under the Apache License, Version 2.0 (the \"License\");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an \"AS IS\" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+################################################################################
+
+  # Carbon Configuration Parameters
+wso2.carbon:
+    # value to uniquely identify a server
+  id: wso2-sp
+    # server name
+  name: WSO2 Stream Processor
+    # ports used by this server
+  ports:
+      # port offset
+    offset: 1
+
+wso2.transport.http:
+  transportProperties:
+    -
+      name: "server.bootstrap.socket.timeout"
+      value: 60
+    -
+      name: "client.bootstrap.socket.timeout"
+      value: 60
+    -
+      name: "latency.metrics.enabled"
+      value: true
+
+  listenerConfigurations:
+    -
+      id: "default"
+      host: "0.0.0.0"
+      port: 9190
+    -
+      id: "msf4j-https"
+      host: "0.0.0.0"
+      port: 9543
+      scheme: https
+      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
+      keyStorePassword: wso2carbon
+      certPass: wso2carbon
+
+  senderConfigurations:
+    -
+      id: "http-sender"
+
+  # Configuration used for the databridge communication
+databridge.config:
+    # No of worker threads to consume events
+    # THIS IS A MANDATORY FIELD
+  workerThreads: 10
+    # Maximum amount of messages that can be queued internally in MB
+    # THIS IS A MANDATORY FIELD
+  maxEventBufferCapacity: 10000000
+    # Queue size; the maximum number of events that can be stored in the queue
+    # THIS IS A MANDATORY FIELD
+  eventBufferSize: 2000
+    # Keystore file path
+    # THIS IS A MANDATORY FIELD
+  keyStoreLocation : ${sys:carbon.home}/resources/security/wso2carbon.jks
+    # Keystore password
+    # THIS IS A MANDATORY FIELD
+  keyStorePassword : wso2carbon
+    # Session Timeout value in mins
+    # THIS IS A MANDATORY FIELD
+  clientTimeoutMin: 30
+    # Data receiver configurations
+    # THIS IS A MANDATORY FIELD
+  dataReceivers:
+  -
+      # Data receiver configuration
+    dataReceiver:
+        # Data receiver type
+        # THIS IS A MANDATORY FIELD
+      type: Thrift
+        # Data receiver properties
+      properties:
+        tcpPort: '7611'
+        sslPort: '7711'
+
+  -
+      # Data receiver configuration
+    dataReceiver:
+        # Data receiver type
+        # THIS IS A MANDATORY FIELD
+      type: Binary
+        # Data receiver properties
+      properties:
+        tcpPort: '9611'
+        sslPort: '9711'
+        tcpReceiverThreadPoolSize: '100'
+        sslReceiverThreadPoolSize: '100'
+        hostName: 0.0.0.0
+
+  # Configuration of the Data Agents - to publish events through databridge
+data.agent.config:
+    # Data agent configurations
+    # THIS IS A MANDATORY FIELD
+  agents:
+  -
+      # Data agent configuration
+    agentConfiguration:
+        # Data agent name
+        # THIS IS A MANDATORY FIELD
+      name: Thrift
+        # Data endpoint class
+        # THIS IS A MANDATORY FIELD
+      dataEndpointClass: org.wso2.carbon.databridge.agent.endpoint.thrift.ThriftDataEndpoint
+        # Data publisher strategy
+      publishingStrategy: async
+        # Trust store path
+      trustStorePath: '${sys:carbon.home}/resources/security/client-truststore.jks'
+        # Trust store password
+      trustStorePassword: 'wso2carbon'
+        # Queue Size
+      queueSize: 32768
+        # Batch Size
+      batchSize: 200
+        # Core pool size
+      corePoolSize: 1
+        # Socket timeout in milliseconds
+      socketTimeoutMS: 30000
+        # Maximum pool size
+      maxPoolSize: 1
+        # Keep alive time in pool
+      keepAliveTimeInPool: 20
+        # Reconnection interval
+      reconnectionInterval: 30
+        # Max transport pool size
+      maxTransportPoolSize: 250
+        # Max idle connections
+      maxIdleConnections: 250
+        # Eviction time interval
+      evictionTimePeriod: 5500
+        # Min idle time in pool
+      minIdleTimeInPool: 5000
+        # Secure max transport pool size
+      secureMaxTransportPoolSize: 250
+        # Secure max idle connections
+      secureMaxIdleConnections: 250
+        # secure eviction time period
+      secureEvictionTimePeriod: 5500
+        # Secure min idle time in pool
+      secureMinIdleTimeInPool: 5000
+        # SSL enabled protocols
+      sslEnabledProtocols: TLSv1.1,TLSv1.2
+        # Ciphers
+      ciphers: TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
+  -
+      # Data agent configuration
+    agentConfiguration:
+        # Data agent name
+        # THIS IS A MANDATORY FIELD
+      name: Binary
+        # Data endpoint class
+        # THIS IS A MANDATORY FIELD
+      dataEndpointClass: org.wso2.carbon.databridge.agent.endpoint.binary.BinaryDataEndpoint
+        # Data publisher strategy
+      publishingStrategy: async
+        # Trust store path
+      trustStorePath: '${sys:carbon.home}/resources/security/client-truststore.jks'
+        # Trust store password
+      trustStorePassword: 'wso2carbon'
+        # Queue Size
+      queueSize: 32768
+        # Batch Size
+      batchSize: 200
+        # Core pool size
+      corePoolSize: 1
+        # Socket timeout in milliseconds
+      socketTimeoutMS: 30000
+        # Maximum pool size
+      maxPoolSize: 1
+        # Keep alive time in pool
+      keepAliveTimeInPool: 20
+        # Reconnection interval
+      reconnectionInterval: 30
+        # Max transport pool size
+      maxTransportPoolSize: 250
+        # Max idle connections
+      maxIdleConnections: 250
+        # Eviction time interval
+      evictionTimePeriod: 5500
+        # Min idle time in pool
+      minIdleTimeInPool: 5000
+        # Secure max transport pool size
+      secureMaxTransportPoolSize: 250
+        # Secure max idle connections
+      secureMaxIdleConnections: 250
+        # secure eviction time period
+      secureEvictionTimePeriod: 5500
+        # Secure min idle time in pool
+      secureMinIdleTimeInPool: 5000
+        # SSL enabled protocols
+      sslEnabledProtocols: TLSv1.1,TLSv1.2
+        # Ciphers
+      ciphers: TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
+
+  # Deployment configuration parameters
+wso2.artifact.deployment:
+    # Scheduler update interval
+  updateInterval: 5
+
+  # Periodic Persistence Configuration
+state.persistence:
+  enabled: false
+  intervalInMin: 1
+  revisionsToKeep: 2
+  persistenceStore: org.wso2.carbon.stream.processor.core.persistence.FileSystemPersistenceStore
+  config:
+    location: siddhi-app-persistence
+
+  # Secure Vault Configuration
+wso2.securevault:
+  secretRepository:
+    type: org.wso2.carbon.secvault.repository.DefaultSecretRepository
+    parameters:
+      privateKeyAlias: wso2carbon
+      keystoreLocation: ${sys:carbon.home}/resources/security/securevault.jks
+      secretPropertiesFile: ${sys:carbon.home}/conf/${sys:wso2.runtime}/secrets.properties
+  masterKeyReader:
+    type: org.wso2.carbon.secvault.reader.DefaultMasterKeyReader
+    parameters:
+      masterKeyReaderFile: ${sys:carbon.home}/conf/${sys:wso2.runtime}/master-keys.yaml
+wso2.datasources:
+  dataSources:
+  - name: SP_MGT_DB
+    description: The datasource used for registry and user manager
+    definition:
+      type: RDBMS
+      configuration:
+        jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/SP_MGT_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000'
+        username: wso2carbon
+        password: wso2carbon
+        driverClassName: org.h2.Driver
+        maxPoolSize: 50
+        idleTimeout: 60000
+        connectionTestQuery: SELECT 1
+        validationTimeout: 30000
+        isAutoCommit: false
+
+  - name: WSO2_PERMISSIONS_DB
+    description: The datasource used for permission feature
+    jndiConfig:
+      name: jdbc/PERMISSION_DB
+      useJndiReference: true
+    definition:
+      type: RDBMS
+      configuration:
+        jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/PERMISSION_DB;IFEXISTS=TRUE;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;MVCC=TRUE'
+        username: wso2carbon
+        password: wso2carbon
+        driverClassName: org.h2.Driver
+        maxPoolSize: 50
+        idleTimeout: 60000
+        connectionTestQuery: SELECT 1
+        validationTimeout: 30000
+        isAutoCommit: false
+
+  # Cluster Configuration
+cluster.config:
+  enabled: false
+  groupId:  sp
+  coordinationStrategyClass: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
+  strategyConfig:
+    datasource: SP_MGT_DB     # define a mysql datasource configured to the shared database
+    heartbeatInterval: 1000
+    heartbeatMaxRetry: 2
+    eventPollingInterval: 1000
+
+  # Deployment Configuration for Distributed Deployment
+deployment.config:
+  type: distributed
+  httpsInterface:
+    host: localhost
+    port: 9543
+  heartbeatInterval: 2000
+  heartbeatMaxRetry: 2
+  datasource: SP_MGT_DB           # define a mysql datasource in datasources and refer it from here.
+  minResourceCount: 1
+  bootstrapURLs: localhost:9092   # kafka urls
+  zooKeeperConfig:
+    zooKeeperURLs: localhost:2181   # zookeeper urls
+    connectionTimeout: 10000
+    sessionTimeout: 10000

--- a/modules/sp_manager/templates/carbon-home/conf/manager/deployment.yaml.erb
+++ b/modules/sp_manager/templates/carbon-home/conf/manager/deployment.yaml.erb
@@ -240,7 +240,7 @@ wso2.datasources:
     definition:
       type: RDBMS
       configuration:
-        jdbcUrl: '<%= @mgt_db_rul %>'
+        jdbcUrl: '<%= @mgt_db_url %>'
         username: <%= @mgt_db_username %>
         password: <%= @mgt_db_password %>
         driverClassName: <%= @mgt_db_dirver %>

--- a/modules/sp_manager/templates/carbon-home/conf/manager/deployment.yaml.erb
+++ b/modules/sp_manager/templates/carbon-home/conf/manager/deployment.yaml.erb
@@ -40,16 +40,16 @@ wso2.transport.http:
   listenerConfigurations:
     -
       id: "default"
-      host: "0.0.0.0"
+      host: "<%= @default_host %>"
       port: 9190
     -
       id: "msf4j-https"
-      host: "0.0.0.0"
+      host: "<%= @msf4j_host %>"
       port: 9543
       scheme: https
-      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
-      keyStorePassword: wso2carbon
-      certPass: wso2carbon
+      keyStoreFile: "<%= @msf4j_keystore_file %>"
+      keyStorePassword: <%= @msf4j_keystore_password %>
+      certPass: <%= @msf4j_cert_pass %>
 
   senderConfigurations:
     -
@@ -68,10 +68,10 @@ databridge.config:
   eventBufferSize: 2000
     # Keystore file path
     # THIS IS A MANDATORY FIELD
-  keyStoreLocation : ${sys:carbon.home}/resources/security/wso2carbon.jks
+  keyStoreLocation : <%= @databridge_keystore_location %>
     # Keystore password
     # THIS IS A MANDATORY FIELD
-  keyStorePassword : wso2carbon
+  keyStorePassword : <%= @databridge_keystore_password %>
     # Session Timeout value in mins
     # THIS IS A MANDATORY FIELD
   clientTimeoutMin: 30
@@ -101,7 +101,7 @@ databridge.config:
         sslPort: '9711'
         tcpReceiverThreadPoolSize: '100'
         sslReceiverThreadPoolSize: '100'
-        hostName: 0.0.0.0
+        hostName: <%= @binary_data_receiver_hostname %>
 
   # Configuration of the Data Agents - to publish events through databridge
 data.agent.config:
@@ -120,9 +120,9 @@ data.agent.config:
         # Data publisher strategy
       publishingStrategy: async
         # Trust store path
-      trustStorePath: '${sys:carbon.home}/resources/security/client-truststore.jks'
+      trustStorePath: '<%= @thrift_agent_trust_store %>'
         # Trust store password
-      trustStorePassword: 'wso2carbon'
+      trustStorePassword: '<%= @thrift_agent_trust_store_password %>'
         # Queue Size
       queueSize: 32768
         # Batch Size
@@ -169,9 +169,9 @@ data.agent.config:
         # Data publisher strategy
       publishingStrategy: async
         # Trust store path
-      trustStorePath: '${sys:carbon.home}/resources/security/client-truststore.jks'
+      trustStorePath: '<%= @binary_agent_trust_store %>'
         # Trust store password
-      trustStorePassword: 'wso2carbon'
+      trustStorePassword: '<%= @binary_agent_trust_store_password %>'
         # Queue Size
       queueSize: 32768
         # Batch Size
@@ -226,13 +226,13 @@ wso2.securevault:
   secretRepository:
     type: org.wso2.carbon.secvault.repository.DefaultSecretRepository
     parameters:
-      privateKeyAlias: wso2carbon
-      keystoreLocation: ${sys:carbon.home}/resources/security/securevault.jks
-      secretPropertiesFile: ${sys:carbon.home}/conf/${sys:wso2.runtime}/secrets.properties
+      privateKeyAlias: <%= @securevault_private_key_alias %>
+      keystoreLocation: <%= @securevault_keystore %>
+      secretPropertiesFile: <%= @securevault_secret_properties_file %>
   masterKeyReader:
     type: org.wso2.carbon.secvault.reader.DefaultMasterKeyReader
     parameters:
-      masterKeyReaderFile: ${sys:carbon.home}/conf/${sys:wso2.runtime}/master-keys.yaml
+      masterKeyReaderFile: <%= @securevault_master_key_reader_file %>
 wso2.datasources:
   dataSources:
   - name: SP_MGT_DB
@@ -240,10 +240,10 @@ wso2.datasources:
     definition:
       type: RDBMS
       configuration:
-        jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/SP_MGT_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000'
-        username: wso2carbon
-        password: wso2carbon
-        driverClassName: org.h2.Driver
+        jdbcUrl: '<%= @mgt_db_rul %>'
+        username: <%= @mgt_db_username %>
+        password: <%= @mgt_db_password %>
+        driverClassName: <%= @mgt_db_dirver %>
         maxPoolSize: 50
         idleTimeout: 60000
         connectionTestQuery: SELECT 1
@@ -270,7 +270,7 @@ wso2.datasources:
 
   # Cluster Configuration
 cluster.config:
-  enabled: false
+  enabled: <%= @cluster_enabled %>
   groupId:  sp
   coordinationStrategyClass: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
   strategyConfig:

--- a/modules/sp_manager/templates/wso2sp-manager.service.erb
+++ b/modules/sp_manager/templates/wso2sp-manager.service.erb
@@ -1,0 +1,19 @@
+[Unit]
+Description=WSO2 Stream Processor - Manager
+After=network.target
+
+[Service]
+ExecStart=<%=@install_path%>/bin/<%=@product_profile%>.sh start
+ExecStop=<%=@install_path%>/bin/<%=@product_profile%>.sh stop
+ExecRestart=<%=@install_path%>/bin/<%=@product_profile%>.sh restart
+PIDFile=<%=@install_path%>/wso2/<%=@product_profile%>/runtime.pid
+User=<%=@user%>
+Group=<%=@user_group%>
+Type=forking
+Restart=on-failure
+RestartSec=5
+StartLimitInterval=60s
+StartLimitBurst=3
+
+[Install]
+WantedBy=multi-user.target

--- a/modules/sp_worker/manifests/custom.pp
+++ b/modules/sp_worker/manifests/custom.pp
@@ -1,0 +1,21 @@
+# ----------------------------------------------------------------------------
+#  Copyright (c) 2018 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# ----------------------------------------------------------------------------
+
+# Class: sp_worker::custom
+# This class is reserved to run custom user code before starting the server.
+class sp_worker::custom {
+  # Resources
+}

--- a/modules/sp_worker/manifests/init.pp
+++ b/modules/sp_worker/manifests/init.pp
@@ -1,0 +1,130 @@
+# ----------------------------------------------------------------------------
+#  Copyright (c) 2018 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# ----------------------------------------------------------------------------
+
+# Class: sp_worker
+# Init class of stream processor all in one profile
+class sp_worker (
+  $user                 = $sp_worker::params::user,
+  $user_id              = $sp_worker::params::user_id,
+  $user_group           = $sp_worker::params::user_group,
+  $user_group_id        = $sp_worker::params::user_group_id,
+  $product_name         = $sp_worker::params::product_name,
+  $service_name         = $sp_worker::params::service_name,
+  $service_profile = $sp_worker::params::service_profile,
+  $start_script_template = $sp_worker::params::start_script_template,
+  $deployment_yaml_template = $sp_worker::params::deployment_yaml_template,
+  $jre_version = $sp_worker::params::jre_version,
+  $clustering = $sp_worker::params::clustering
+)
+inherits sp_worker::params {
+
+  if $::osfamily == 'redhat' {
+    $sp_package = 'wso2sp-linux-installer-x64-4.2.0.rpm'
+    $installer_provider = 'rpm'
+    $install_path = '/usr/lib64/wso2/wso2sp/4.2.0'
+  }
+  elsif $::osfamily == 'debian' {
+    $sp_package = 'wso2sp-linux-installer-x64-4.2.0.deb'
+    $installer_provider = 'dpkg'
+    $install_path = '/usr/lib/wso2/wso2sp/4.2.0'
+  }
+
+  # Create wso2 group
+  group { $user_group:
+    ensure => present,
+    gid    => $user_group_id,
+    system => true,
+  }
+
+  # Create wso2 user
+  user { $user:
+    ensure => present,
+    uid    => $user_id,
+    gid    => $user_group_id,
+    home   => "/home/${user}",
+    system => true,
+  }
+  # Ensure the installation directory is available
+  file { "/opt/${product_name}":
+    ensure => 'directory',
+    owner  => $user,
+    group  => $user_group,
+  }
+
+  # Copy the installer to the directory
+  file { "/opt/${product_name}/${sp_package}":
+    owner  => $user,
+    group  => $user_group,
+    mode   => '0644',
+    source => "puppet:///modules/${module_name}/${sp_package}",
+  }
+
+  # Install WSO2 API Manager
+  package { $product_name:
+    ensure   => installed,
+    provider => $installer_provider,
+    source   => "/opt/${product_name}/${sp_package}"
+  }
+
+  # Change the ownership of the installation directory to wso2 user & group
+  file { $install_path:
+    ensure  => directory,
+    owner   => $user,
+    group   => $user_group,
+    require => [ User[$user], Group[$user_group]],
+    recurse => true
+  }
+
+  # Copy deployment.yaml to the installed directory
+  file { "${install_path}/${deployment_yaml_template}":
+    ensure  => file,
+    owner   => $user,
+    group   => $user_group,
+    mode    => '0644',
+    content => template("${module_name}/carbon-home/${deployment_yaml_template}.erb")
+  }
+
+  # Copy dashboard.sh to installed directory
+  file { "${install_path}/${start_script_template}":
+    ensure  => file,
+    owner   => $user,
+    group   => $user_group,
+    mode    => '0754',
+    content => template("${module_name}/carbon-home/${start_script_template}.erb")
+  }
+
+  # Copy the unit file required to deploy the server as a service
+  file { "/etc/systemd/system/${service_name}.service":
+    ensure  => present,
+    owner   => root,
+    group   => root,
+    mode    => '0754',
+    content => template("${module_name}/${service_name}.service.erb"),
+  }
+
+  /*
+    Following script can be used to copy file to a given location.
+    This will copy some_file to install_path -> repository.
+    Note: Ensure
+    that file is available in modules -> sp_dashboard -> files
+  */
+  # file { "${install_path}/repository/some_file":
+  #   owner  => $user,
+  #   group  => $user_group,
+  #   mode   => '0644',
+  #   source => "puppet:///modules/${module_name}/some_file",
+  # }
+}

--- a/modules/sp_worker/manifests/init.pp
+++ b/modules/sp_worker/manifests/init.pp
@@ -108,7 +108,7 @@ inherits sp_worker::params {
     source => "puppet:///modules/${module_name}/${sp_package}",
   }
 
-  # Install WSO2 API Manager
+  # Install WSO2 Stream Processor
   package { $product_name:
     ensure   => installed,
     provider => $installer_provider,

--- a/modules/sp_worker/manifests/init.pp
+++ b/modules/sp_worker/manifests/init.pp
@@ -27,7 +27,43 @@ class sp_worker (
   $start_script_template = $sp_worker::params::start_script_template,
   $deployment_yaml_template = $sp_worker::params::deployment_yaml_template,
   $jre_version = $sp_worker::params::jre_version,
-  $clustering = $sp_worker::params::clustering
+  $clustering = $sp_worker::params::clustering,
+
+  # -------- deployment.yaml configs --------
+
+  # listenerConfigurations
+  $default_host = $sp_worker::params::default_host,
+
+  $msf4j_host = $sp_worker::params::msf4j_host,
+  $msf4j_keystore_file = $sp_worker::params::msf4j_keystore_file,
+  $msf4j_keystore_password = $sp_worker::params::msf4j_keystore_password,
+  $msf4j_cert_pass = $sp_worker::params::msf4j_cert_pass,
+
+  # Configuration used for the databridge communication
+  $databridge_keystore_location = $sp_worker::params::databridge_keystore_location,
+  $databridge_keystore_password = $sp_worker::params::databridge_keystore_password,
+  $binary_data_receiver_hostname = $sp_worker::params::binary_data_receiver_hostname,
+
+  # Configuration of the Data Agents - to publish events through databridge
+  $thrift_agent_trust_store = $sp_worker::params::thrift_agent_trust_store,
+  $thrift_agent_trust_store_password = $sp_worker::params::thrift_agent_trust_store_password,
+  $binary_agent_trust_store = $sp_worker::params::binary_agent_trust_store,
+  $binary_agent_trust_store_password = $sp_worker::params::binary_agent_trust_store_password,
+
+  # Secure Vault Configuration
+  $securevault_private_key_alias = $sp_worker::params::securevault_private_key_alias,
+  $securevault_keystore = $sp_worker::params::securevault_keystore,
+  $securevault_secret_properties_file = $sp_worker::params::securevault_secret_properties_file,
+  $securevault_master_key_reader_file = $sp_worker::params::securevault_master_key_reader_file,
+
+  # Datasource Configurations
+  $carbon_db_rul = $sp_worker::params::carbon_db_rul,
+  $carbon_db_username = $sp_worker::params::carbon_db_username,
+  $carbon_db_password = $sp_worker::params::carbon_db_password,
+  $carbon_db_dirver = $sp_worker::params::carbon_db_dirver,
+
+  # Cluster Configuration
+  $cluster_enabled = $sp_worker::params::cluster_enabled,
 )
 inherits sp_worker::params {
 

--- a/modules/sp_worker/manifests/init.pp
+++ b/modules/sp_worker/manifests/init.pp
@@ -57,7 +57,7 @@ class sp_worker (
   $securevault_master_key_reader_file = $sp_worker::params::securevault_master_key_reader_file,
 
   # Datasource Configurations
-  $carbon_db_rul = $sp_worker::params::carbon_db_rul,
+  $carbon_db_url = $sp_worker::params::carbon_db_url,
   $carbon_db_username = $sp_worker::params::carbon_db_username,
   $carbon_db_password = $sp_worker::params::carbon_db_password,
   $carbon_db_dirver = $sp_worker::params::carbon_db_dirver,

--- a/modules/sp_worker/manifests/params.pp
+++ b/modules/sp_worker/manifests/params.pp
@@ -30,4 +30,40 @@ class sp_worker::params {
   # Define the template
   $start_script_template = "bin/${product_profile}.sh"
   $deployment_yaml_template = "conf/${product_profile}/deployment.yaml"
+
+  # -------- deployment.yaml configs --------
+
+  # listenerConfigurations
+  $default_host = '0.0.0.0'
+
+  $msf4j_host = '0.0.0.0'
+  $msf4j_keystore_file = '${carbon.home}/resources/security/wso2carbon.jks'
+  $msf4j_keystore_password = 'wso2carbon'
+  $msf4j_cert_pass = 'wso2carbon'
+
+  # Configuration used for the databridge communication
+  $databridge_keystore_location = '${sys:carbon.home}/resources/security/wso2carbon.jks'
+  $databridge_keystore_password = 'wso2carbon'
+  $binary_data_receiver_hostname = '0.0.0.0'
+
+  # Configuration of the Data Agents - to publish events through databridge
+  $thrift_agent_trust_store = '${sys:carbon.home}/resources/security/client-truststore.jks'
+  $thrift_agent_trust_store_password = 'wso2carbon'
+  $binary_agent_trust_store = '${sys:carbon.home}/resources/security/client-truststore.jks'
+  $binary_agent_trust_store_password = 'wso2carbon'
+
+  # Secure Vault Configuration
+  $securevault_private_key_alias = 'wso2carbon'
+  $securevault_keystore = '${sys:carbon.home}/resources/security/securevault.jks'
+  $securevault_secret_properties_file = '${sys:carbon.home}/conf/${sys:wso2.runtime}/secrets.properties'
+  $securevault_master_key_reader_file = '${sys:carbon.home}/conf/${sys:wso2.runtime}/master-keys.yaml'
+
+  # Datasource Configurations
+  $carbon_db_url = 'jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/WSO2_CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000'
+  $carbon_db_username = 'wso2carbon'
+  $carbon_db_password = 'wso2carbon'
+  $carbon_db_dirver = 'org.h2.Driver'
+
+  # Cluster Configuration
+  $cluster_enabled = 'false'
 }

--- a/modules/sp_worker/manifests/params.pp
+++ b/modules/sp_worker/manifests/params.pp
@@ -1,0 +1,33 @@
+# ----------------------------------------------------------------------------
+#  Copyright (c) 2018 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# ----------------------------------------------------------------------------
+
+# Claas sp_worker::params
+# This class includes all the necessary parameters
+class sp_worker::params {
+  $user = 'wso2carbon'
+  $user_id = 802
+  $user_group = 'wso2'
+  $user_home = '/home/$user'
+  $user_group_id = 802
+  $product_name = 'wso2sp'
+  $product_profile = 'worker'
+  $service_name = "${product_name}-${product_profile}"
+  $jre_version = 'jre1.8.0_172'
+
+  # Define the template
+  $start_script_template = "bin/${product_profile}.sh"
+  $deployment_yaml_template = "conf/${product_profile}/deployment.yaml"
+}

--- a/modules/sp_worker/manifests/startserver.pp
+++ b/modules/sp_worker/manifests/startserver.pp
@@ -1,0 +1,28 @@
+# ----------------------------------------------------------------------------
+#  Copyright (c) 2018 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# ----------------------------------------------------------------------------
+
+# Class sp_worker::startserver
+#
+class sp_worker::startserver (
+  $service_name = $sp_worker::params::service_name
+)
+  inherits sp_worker::params {
+
+  service { $service_name:
+    ensure => running,
+    enable => true
+  }
+}

--- a/modules/sp_worker/templates/carbon-home/bin/worker.sh.erb
+++ b/modules/sp_worker/templates/carbon-home/bin/worker.sh.erb
@@ -1,0 +1,67 @@
+#!/bin/sh
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+export JAVA_HOME="<%=@install_path%>/jre/<%=@jre_version%>"
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+             JAVA_VERSION="CurrentJDK"
+           else
+             echo "Using Java version: $JAVA_VERSION"
+           fi
+           if [ -z "$JAVA_HOME" ] ; then
+             JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+           fi
+           ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+[ -z "$RUNTIME_HOME" ] && RUNTIME_HOME=`cd "$PRGDIR/../wso2/worker" ; pwd`
+
+###########################################################################
+NAME=start-worker
+# Daemon name, where is the actual executable
+
+WORKER_INIT_SCRIPT="$CARBON_HOME/wso2/worker/bin/carbon.sh"
+
+# If the daemon is not there, then exit.
+$WORKER_INIT_SCRIPT $*
+exit;

--- a/modules/sp_worker/templates/carbon-home/conf/worker/deployment.yaml.erb
+++ b/modules/sp_worker/templates/carbon-home/conf/worker/deployment.yaml.erb
@@ -1,0 +1,445 @@
+################################################################################
+#   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved
+#
+#   Licensed under the Apache License, Version 2.0 (the \"License\");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an \"AS IS\" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+################################################################################
+
+  # Carbon Configuration Parameters
+wso2.carbon:
+    # value to uniquely identify a server
+  id: wso2-sp
+    # server name
+  name: WSO2 Stream Processor
+    # ports used by this server
+  ports:
+      # port offset
+    offset: 0
+
+wso2.transport.http:
+  transportProperties:
+    -
+      name: "server.bootstrap.socket.timeout"
+      value: 60
+    -
+      name: "client.bootstrap.socket.timeout"
+      value: 60
+    -
+      name: "latency.metrics.enabled"
+      value: true
+
+  listenerConfigurations:
+    -
+      id: "default"
+      host: "0.0.0.0"
+      port: 9090
+    -
+      id: "msf4j-https"
+      host: "0.0.0.0"
+      port: 9443
+      scheme: https
+      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
+      keyStorePassword: wso2carbon
+      certPass: wso2carbon
+
+  senderConfigurations:
+    -
+      id: "http-sender"
+
+  # Configuration used for the databridge communication
+databridge.config:
+    # No of worker threads to consume events
+    # THIS IS A MANDATORY FIELD
+  workerThreads: 10
+    # Maximum amount of messages that can be queued internally in MB
+    # THIS IS A MANDATORY FIELD
+  maxEventBufferCapacity: 10000000
+    # Queue size; the maximum number of events that can be stored in the queue
+    # THIS IS A MANDATORY FIELD
+  eventBufferSize: 2000
+    # Keystore file path
+    # THIS IS A MANDATORY FIELD
+  keyStoreLocation : ${sys:carbon.home}/resources/security/wso2carbon.jks
+    # Keystore password
+    # THIS IS A MANDATORY FIELD
+  keyStorePassword : wso2carbon
+    # Session Timeout value in mins
+    # THIS IS A MANDATORY FIELD
+  clientTimeoutMin: 30
+    # Data receiver configurations
+    # THIS IS A MANDATORY FIELD
+  dataReceivers:
+  -
+      # Data receiver configuration
+    dataReceiver:
+        # Data receiver type
+        # THIS IS A MANDATORY FIELD
+      type: Thrift
+        # Data receiver properties
+      properties:
+        tcpPort: '7611'
+        sslPort: '7711'
+
+  -
+      # Data receiver configuration
+    dataReceiver:
+        # Data receiver type
+        # THIS IS A MANDATORY FIELD
+      type: Binary
+        # Data receiver properties
+      properties:
+        tcpPort: '9611'
+        sslPort: '9711'
+        tcpReceiverThreadPoolSize: '100'
+        sslReceiverThreadPoolSize: '100'
+        hostName: 0.0.0.0
+
+  # Configuration of the Data Agents - to publish events through databridge
+data.agent.config:
+    # Data agent configurations
+    # THIS IS A MANDATORY FIELD
+  agents:
+  -
+      # Data agent configuration
+    agentConfiguration:
+        # Data agent name
+        # THIS IS A MANDATORY FIELD
+      name: Thrift
+        # Data endpoint class
+        # THIS IS A MANDATORY FIELD
+      dataEndpointClass: org.wso2.carbon.databridge.agent.endpoint.thrift.ThriftDataEndpoint
+        # Data publisher strategy
+      publishingStrategy: async
+        # Trust store path
+      trustStorePath: '${sys:carbon.home}/resources/security/client-truststore.jks'
+        # Trust store password
+      trustStorePassword: 'wso2carbon'
+        # Queue Size
+      queueSize: 32768
+        # Batch Size
+      batchSize: 200
+        # Core pool size
+      corePoolSize: 1
+        # Socket timeout in milliseconds
+      socketTimeoutMS: 30000
+        # Maximum pool size
+      maxPoolSize: 1
+        # Keep alive time in pool
+      keepAliveTimeInPool: 20
+        # Reconnection interval
+      reconnectionInterval: 30
+        # Max transport pool size
+      maxTransportPoolSize: 250
+        # Max idle connections
+      maxIdleConnections: 250
+        # Eviction time interval
+      evictionTimePeriod: 5500
+        # Min idle time in pool
+      minIdleTimeInPool: 5000
+        # Secure max transport pool size
+      secureMaxTransportPoolSize: 250
+        # Secure max idle connections
+      secureMaxIdleConnections: 250
+        # secure eviction time period
+      secureEvictionTimePeriod: 5500
+        # Secure min idle time in pool
+      secureMinIdleTimeInPool: 5000
+        # SSL enabled protocols
+      sslEnabledProtocols: TLSv1.1,TLSv1.2
+        # Ciphers
+      ciphers: TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
+  -
+      # Data agent configuration
+    agentConfiguration:
+        # Data agent name
+        # THIS IS A MANDATORY FIELD
+      name: Binary
+        # Data endpoint class
+        # THIS IS A MANDATORY FIELD
+      dataEndpointClass: org.wso2.carbon.databridge.agent.endpoint.binary.BinaryDataEndpoint
+        # Data publisher strategy
+      publishingStrategy: async
+        # Trust store path
+      trustStorePath: '${sys:carbon.home}/resources/security/client-truststore.jks'
+        # Trust store password
+      trustStorePassword: 'wso2carbon'
+        # Queue Size
+      queueSize: 32768
+        # Batch Size
+      batchSize: 200
+        # Core pool size
+      corePoolSize: 1
+        # Socket timeout in milliseconds
+      socketTimeoutMS: 30000
+        # Maximum pool size
+      maxPoolSize: 1
+        # Keep alive time in pool
+      keepAliveTimeInPool: 20
+        # Reconnection interval
+      reconnectionInterval: 30
+        # Max transport pool size
+      maxTransportPoolSize: 250
+        # Max idle connections
+      maxIdleConnections: 250
+        # Eviction time interval
+      evictionTimePeriod: 5500
+        # Min idle time in pool
+      minIdleTimeInPool: 5000
+        # Secure max transport pool size
+      secureMaxTransportPoolSize: 250
+        # Secure max idle connections
+      secureMaxIdleConnections: 250
+        # secure eviction time period
+      secureEvictionTimePeriod: 5500
+        # Secure min idle time in pool
+      secureMinIdleTimeInPool: 5000
+        # SSL enabled protocols
+      sslEnabledProtocols: TLSv1.1,TLSv1.2
+        # Ciphers
+      ciphers: TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
+
+# This is the main configuration for metrics
+wso2.metrics:
+  # Enable Metrics
+  enabled: false
+  reporting:
+    console:
+      - # The name for the Console Reporter
+        name: Console
+
+        # Enable Console Reporter
+        enabled: false
+
+        # Polling Period in seconds.
+        # This is the period for polling metrics from the metric registry and printing in the console
+        pollingPeriod: 5
+
+wso2.metrics.jdbc:
+  # Data Source Configurations for JDBC Reporters
+  dataSource:
+    # Default Data Source Configuration
+    - &JDBC01
+      # JNDI name of the data source to be used by the JDBC Reporter.
+      # This data source should be defined in a *-datasources.xml file in conf/datasources directory.
+      dataSourceName: java:comp/env/jdbc/WSO2MetricsDB
+      # Schedule regular deletion of metrics data older than a set number of days.
+      # It is recommended that you enable this job to ensure your metrics tables do not get extremely large.
+      # Deleting data older than seven days should be sufficient.
+      scheduledCleanup:
+        # Enable scheduled cleanup to delete Metrics data in the database.
+        enabled: true
+
+        # The scheduled job will cleanup all data older than the specified days
+        daysToKeep: 3
+
+        # This is the period for each cleanup operation in seconds.
+        scheduledCleanupPeriod: 86400
+
+  # The JDBC Reporter is in the Metrics JDBC Core feature
+  reporting:
+    # The JDBC Reporter configurations will be ignored if the Metrics JDBC Core feature is not available in runtime
+    jdbc:
+      - # The name for the JDBC Reporter
+        name: JDBC
+
+        # Enable JDBC Reporter
+        enabled: true
+
+        # Source of Metrics, which will be used to identify each metric in database -->
+        # Commented to use the hostname by default
+        # source: Carbon
+
+        # Alias referring to the Data Source configuration
+        dataSource: *JDBC01
+
+        # Polling Period in seconds.
+        # This is the period for polling metrics from the metric registry and updating the database with the values
+        pollingPeriod: 60
+
+  # Deployment configuration parameters
+wso2.artifact.deployment:
+    # Scheduler update interval
+  updateInterval: 5
+
+  # Periodic Persistence Configuration
+state.persistence:
+  enabled: false
+  intervalInMin: 1
+  revisionsToKeep: 2
+  persistenceStore: org.wso2.carbon.stream.processor.core.persistence.FileSystemPersistenceStore
+  config:
+    location: siddhi-app-persistence
+
+  # Secure Vault Configuration
+wso2.securevault:
+  secretRepository:
+    type: org.wso2.carbon.secvault.repository.DefaultSecretRepository
+    parameters:
+      privateKeyAlias: wso2carbon
+      keystoreLocation: ${sys:carbon.home}/resources/security/securevault.jks
+      secretPropertiesFile: ${sys:carbon.home}/conf/${sys:wso2.runtime}/secrets.properties
+  masterKeyReader:
+    type: org.wso2.carbon.secvault.reader.DefaultMasterKeyReader
+    parameters:
+      masterKeyReaderFile: ${sys:carbon.home}/conf/${sys:wso2.runtime}/master-keys.yaml
+
+  # Datasource Configurations
+wso2.datasources:
+  dataSources:
+    -
+      definition:
+        configuration:
+          connectionTestQuery: "SELECT 1"
+          driverClassName: org.h2.Driver
+          idleTimeout: 60000
+          isAutoCommit: false
+          jdbcUrl: "jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/WSO2_CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000"
+          maxPoolSize: 50
+          password: wso2carbon
+          username: wso2carbon
+          validationTimeout: 30000
+        type: RDBMS
+      description: "The datasource used for registry and user manager"
+      name: WSO2_CARBON_DB
+
+    # carbon metrics data source
+    - name: WSO2_METRICS_DB
+      description: The datasource used for dashboard feature
+      jndiConfig:
+        name: jdbc/WSO2MetricsDB
+      definition:
+        type: RDBMS
+        configuration:
+          jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/dashboard/database/metrics;AUTO_SERVER=TRUE'
+          username: wso2carbon
+          password: wso2carbon
+          driverClassName: org.h2.Driver
+          maxPoolSize: 50
+          idleTimeout: 60000
+          connectionTestQuery: SELECT 1
+          validationTimeout: 30000
+          isAutoCommit: false
+
+    - name: WSO2_PERMISSIONS_DB
+      description: The datasource used for permission feature
+      jndiConfig:
+        name: jdbc/PERMISSION_DB
+        useJndiReference: true
+      definition:
+        type: RDBMS
+        configuration:
+          jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/PERMISSION_DB;IFEXISTS=TRUE;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;MVCC=TRUE'
+          username: wso2carbon
+          password: wso2carbon
+          driverClassName: org.h2.Driver
+          maxPoolSize: 50
+          idleTimeout: 60000
+          connectionTestQuery: SELECT 1
+          validationTimeout: 30000
+          isAutoCommit: false
+
+    - name: HTTP_ANALYTICS_DB
+      description: The datasource used for HTTP Analytics dashboard
+      jndiConfig:
+        name: jdbc/HTTP_ANALYTICS_DB
+        useJndiReference: false
+      definition:
+        type: RDBMS
+        configuration:
+          jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/worker/database/HTTP_ANALYTICS_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;MVCC=TRUE;AUTO_SERVER=TRUE'
+          username: wso2carbon
+          password: wso2carbon
+          driverClassName: org.h2.Driver
+          maxPoolSize: 50
+          idleTimeout: 60000
+          connectionTestQuery: SELECT 1
+          validationTimeout: 30000
+          isAutoCommit: false
+    - name: Twitter_Analytics
+      description: The datasource used for Twitter Analytics dashboard
+      jndiConfig:
+        name: jdbc/Twitter_Analytics
+        useJndiReference: false
+      definition:
+        type: RDBMS
+        configuration:
+          jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/worker/database/Twitter_Analytics;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;MVCC=TRUE;AUTO_SERVER=TRUE'
+          username: wso2carbon
+          password: wso2carbon
+          driverClassName: org.h2.Driver
+          maxPoolSize: 50
+          idleTimeout: 60000
+          connectionTestQuery: SELECT 1
+          validationTimeout: 30000
+          isAutoCommit: false
+
+    - name: Message_Tracing_DB
+      description: "The datasource used for message tracer to store span information."
+      jndiConfig:
+        name: jdbc/Message_Tracing_DB
+      definition:
+        type: RDBMS
+        configuration:
+          jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/dashboard/database/MESSAGE_TRACING_DB;AUTO_SERVER=TRUE'
+          username: wso2carbon
+          password: wso2carbon
+          driverClassName: org.h2.Driver
+          maxPoolSize: 50
+          idleTimeout: 60000
+          connectionTestQuery: SELECT 1
+          validationTimeout: 30000
+          isAutoCommit: false
+
+  # Cluster Configuration
+cluster.config:
+  enabled: false
+  groupId:  sp
+  coordinationStrategyClass: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
+  strategyConfig:
+    datasource: WSO2_CARBON_DB
+    heartbeatInterval: 1000
+    heartbeatMaxRetry: 2
+    eventPollingInterval: 1000
+
+  # Sample of deployment.config for Two node HA
+#deployment.config:
+#  type: ha
+#  liveSync:
+#    enabled: true
+#    advertisedHost: localhost
+#    advertisedPort: 9090
+#    username: admin
+#    password: admin
+#  outputSyncInterval: 10000
+#  stateSyncGracePeriod: 60000
+#  sinkQueueCapacity: 20000
+#  sourceQueueCapacity: 20000
+#  retryAppSyncPeriod: 60000
+
+  # Sample of deployment.config for Distributed deployment
+#deployment.config:
+#  type: distributed
+#  httpsInterface:
+#    host: 192.168.1.3
+#    port: 9443
+#    username: admin
+#    password: admin
+#  leaderRetryInterval: 10000
+#  resourceManagers:
+#    - host: 192.168.1.1
+#      port: 9543
+#      username: admin
+#      password: admin
+#    - host: 192.168.1.2
+#      port: 9543
+#      username: admin
+#      password: admin

--- a/modules/sp_worker/templates/carbon-home/conf/worker/deployment.yaml.erb
+++ b/modules/sp_worker/templates/carbon-home/conf/worker/deployment.yaml.erb
@@ -40,16 +40,16 @@ wso2.transport.http:
   listenerConfigurations:
     -
       id: "default"
-      host: "0.0.0.0"
+      host: "<%= @default_host %>"
       port: 9090
     -
       id: "msf4j-https"
-      host: "0.0.0.0"
+      host: "<%= @msf4j_host %>"
       port: 9443
       scheme: https
-      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
-      keyStorePassword: wso2carbon
-      certPass: wso2carbon
+      keyStoreFile: "<%= @msf4j_keystore_file %>"
+      keyStorePassword: <%= @msf4j_keystore_password %>
+      certPass: <%= @msf4j_cert_pass %>
 
   senderConfigurations:
     -
@@ -68,10 +68,10 @@ databridge.config:
   eventBufferSize: 2000
     # Keystore file path
     # THIS IS A MANDATORY FIELD
-  keyStoreLocation : ${sys:carbon.home}/resources/security/wso2carbon.jks
+  keyStoreLocation : <%= @databridge_keystore_location %>
     # Keystore password
     # THIS IS A MANDATORY FIELD
-  keyStorePassword : wso2carbon
+  keyStorePassword : <%= @databridge_keystore_password %>
     # Session Timeout value in mins
     # THIS IS A MANDATORY FIELD
   clientTimeoutMin: 30
@@ -101,7 +101,7 @@ databridge.config:
         sslPort: '9711'
         tcpReceiverThreadPoolSize: '100'
         sslReceiverThreadPoolSize: '100'
-        hostName: 0.0.0.0
+        hostName: <%= @binary_data_receiver_hostname %>
 
   # Configuration of the Data Agents - to publish events through databridge
 data.agent.config:
@@ -120,9 +120,9 @@ data.agent.config:
         # Data publisher strategy
       publishingStrategy: async
         # Trust store path
-      trustStorePath: '${sys:carbon.home}/resources/security/client-truststore.jks'
+      trustStorePath: '<%= @thrift_agent_trust_store %>'
         # Trust store password
-      trustStorePassword: 'wso2carbon'
+      trustStorePassword: '<%= @thrift_agent_trust_store_password %>'
         # Queue Size
       queueSize: 32768
         # Batch Size
@@ -169,9 +169,9 @@ data.agent.config:
         # Data publisher strategy
       publishingStrategy: async
         # Trust store path
-      trustStorePath: '${sys:carbon.home}/resources/security/client-truststore.jks'
+      trustStorePath: '<%= @binary_agent_trust_store %>'
         # Trust store password
-      trustStorePassword: 'wso2carbon'
+      trustStorePassword: '<%= @binary_agent_trust_store_password %>'
         # Queue Size
       queueSize: 32768
         # Batch Size
@@ -284,13 +284,13 @@ wso2.securevault:
   secretRepository:
     type: org.wso2.carbon.secvault.repository.DefaultSecretRepository
     parameters:
-      privateKeyAlias: wso2carbon
-      keystoreLocation: ${sys:carbon.home}/resources/security/securevault.jks
-      secretPropertiesFile: ${sys:carbon.home}/conf/${sys:wso2.runtime}/secrets.properties
+      privateKeyAlias: <%= @securevault_private_key_alias %>
+      keystoreLocation: <%= @securevault_keystore %>
+      secretPropertiesFile: <%= @securevault_secret_properties_file %>
   masterKeyReader:
     type: org.wso2.carbon.secvault.reader.DefaultMasterKeyReader
     parameters:
-      masterKeyReaderFile: ${sys:carbon.home}/conf/${sys:wso2.runtime}/master-keys.yaml
+      masterKeyReaderFile: <%= @securevault_master_key_reader_file %>
 
   # Datasource Configurations
 wso2.datasources:
@@ -299,13 +299,13 @@ wso2.datasources:
       definition:
         configuration:
           connectionTestQuery: "SELECT 1"
-          driverClassName: org.h2.Driver
+          driverClassName: <%= @carbon_db_dirver %>
           idleTimeout: 60000
           isAutoCommit: false
-          jdbcUrl: "jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/WSO2_CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000"
+          jdbcUrl: "<%= @carbon_db_url %>"
           maxPoolSize: 50
-          password: wso2carbon
-          username: wso2carbon
+          password: <%= @carbon_db_password %>
+          username: <%= @carbon_db_username %>
           validationTimeout: 30000
         type: RDBMS
       description: "The datasource used for registry and user manager"
@@ -401,7 +401,7 @@ wso2.datasources:
 
   # Cluster Configuration
 cluster.config:
-  enabled: false
+  enabled: <%= @cluster_enabled %>
   groupId:  sp
   coordinationStrategyClass: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
   strategyConfig:

--- a/modules/sp_worker/templates/wso2sp-worker.service.erb
+++ b/modules/sp_worker/templates/wso2sp-worker.service.erb
@@ -1,5 +1,5 @@
 [Unit]
-Description=WSO2 Stream Processor - Manager
+Description=WSO2 Stream Processor - Worker
 After=network.target
 
 [Service]

--- a/modules/sp_worker/templates/wso2sp-worker.service.erb
+++ b/modules/sp_worker/templates/wso2sp-worker.service.erb
@@ -1,0 +1,19 @@
+[Unit]
+Description=WSO2 Stream Processor - Manager
+After=network.target
+
+[Service]
+ExecStart=<%=@install_path%>/bin/<%=@product_profile%>.sh start
+ExecStop=<%=@install_path%>/bin/<%=@product_profile%>.sh stop
+ExecRestart=<%=@install_path%>/bin/<%=@product_profile%>.sh restart
+PIDFile=<%=@install_path%>/wso2/<%=@product_profile%>/runtime.pid
+User=<%=@user%>
+Group=<%=@user_group%>
+Type=forking
+Restart=on-failure
+RestartSec=5
+StartLimitInterval=60s
+StartLimitBurst=3
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Purpose
> Make Puppet 5 modules available for stream processor 4.2.0

## Goals
> Complete puppet 5 modules for WSO2 Products

## Approach
> Create puppet 5 modules for each runtime of Stream Processor

## Test environment
> Operating systems:
> - Ubuntu 18.04 LTS
> - CentOS 7

> Puppet version:  5.0
