### PR TITLE
Add agent spefcific configurations

### DIFF
--- a/modules/common/manifests/params.pp
+++ b/modules/common/manifests/params.pp
@@ -1,0 +1,37 @@
+#----------------------------------------------------------------------------
+#  Copyright (c) 2019 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#----------------------------------------------------------------------------
+
+class common::params {
+
+  # -------- deployment.yaml configs --------
+
+  # databridge.config
+  $databridge_keystore_location = '${sys:carbon.home}/resources/security/wso2carbon.jks'
+  $databridge_keystore_password = 'wso2carbon'
+  $binary_data_receiver_hostname = '0.0.0.0'
+
+  # Configuration of the Data Agents - to publish events through databridge
+  $thrift_agent_trust_store = '${sys:carbon.home}/resources/security/client-truststore.jks'
+  $thrift_agent_trust_store_password = 'wso2carbon'
+  $binary_agent_trust_store = '${sys:carbon.home}/resources/security/client-truststore.jks'
+  $binary_agent_trust_store_password = 'wso2carbon'
+
+  # Secure Vault Configuration
+  $securevault_private_key_alias = 'wso2carbon'
+  $securevault_keystore = '${sys:carbon.home}/resources/security/securevault.jks'
+  $securevault_secret_properties_file = '${sys:carbon.home}/conf/${sys:wso2.runtime}/secrets.properties'
+  $securevault_master_key_reader_file = '${sys:carbon.home}/conf/${sys:wso2.runtime}/master-keys.yaml'
+}

--- a/modules/sp_dashboard/manifests/init.pp
+++ b/modules/sp_dashboard/manifests/init.pp
@@ -148,6 +148,13 @@ class sp_dashboard inherits sp_dashboard::params {
     content => template("${module_name}/${service_name}.service.erb"),
   }
 
+  # Add agent specific file configurations
+  # $config_file_list.each |$config_file| {
+  #   exec { "sed -i -e 's/${config_file['key']}/${config_file['value']}/g' ${config_file['file']}":
+  #     path => "/bin/",
+  #   }
+  # }
+
   /*
     Following script can be used to copy file to a given location.
     This will copy some_file to install_path -> repository.

--- a/modules/sp_dashboard/manifests/init.pp
+++ b/modules/sp_dashboard/manifests/init.pp
@@ -46,7 +46,7 @@ class sp_dashboard inherits sp_dashboard::params {
   # Copy JDK to Java distribution path
   file { "jdk-distribution":
     path   => "${java_home}.tar.gz",
-    source => "puppet:///modules/distributions/${jdk_name}.tar.gz",
+    source => "puppet:///modules/common/${jdk_name}.tar.gz",
   }
 
   # Unzip distribution

--- a/modules/sp_dashboard/manifests/params.pp
+++ b/modules/sp_dashboard/manifests/params.pp
@@ -44,4 +44,21 @@ class sp_dashboard::params {
   $product_binary = "${product}-${product_version}.zip"
   $distribution_path = "${products_dir}/${product}/${product_profile}/${product_version}"
   $install_path = "${distribution_path}/${product}-${product_version}"
+
+  # List of files that must contain agent specific configuraitons
+  # if $deployment == "dev" {
+  #   $config_file_list = [
+  #     { "file" => "${install_path}/file1", "key" => "key1", "value" => "value1" },
+  #   ]
+  # }
+  # elsif $deployment == "staging" {
+  #   $config_file_list = [
+  #     { "file" => "${install_path}/file1", "key" => "key1", "value" => "value1" },
+  #   ]
+  # }
+  # elsif $deployment == "production" {
+  #   $config_file_list = [
+  #     { "file" => "${install_path}/file1", "key" => "key1", "value" => "value1" },
+  #   ]
+  # }
 }

--- a/modules/sp_dashboard_master/manifests/init.pp
+++ b/modules/sp_dashboard_master/manifests/init.pp
@@ -30,7 +30,7 @@ class sp_dashboard_master inherits sp_dashboard_master::params {
   file { "binary":
     path   => "${distribution_path}/${product_binary}",
     mode   => '0644',
-    source => "puppet:///modules/distributions/${product_binary}",
+    source => "puppet:///modules/common/${product_binary}",
   }
 
   # Install the "unzip" package

--- a/modules/sp_dashboard_master/manifests/params.pp
+++ b/modules/sp_dashboard_master/manifests/params.pp
@@ -16,7 +16,7 @@
 
 # Claas sp_dashboard_master::params
 # This class includes all the necessary parameters
-class sp_dashboard_master::params {
+class sp_dashboard_master::params inherits common::params {
   $user = 'wso2carbon'
   $user_group = 'wso2'
   $product = 'wso2sp'
@@ -27,23 +27,6 @@ class sp_dashboard_master::params {
   $deployment_yaml_template = "conf/${product_profile}/deployment.yaml"
 
   # -------- deployment.yaml configs --------
-
-  # databridge.config
-  $databridge_keystore_location = '${sys:carbon.home}/resources/security/wso2carbon.jks'
-  $databridge_keystore_password = 'wso2carbon'
-  $binary_data_receiver_hostname = '0.0.0.0'
-
-  # data.agent.config
-  $thrift_agent_trust_store = '${sys:carbon.home}/resources/security/client-truststore.jks'
-  $thrift_agent_trust_store_password = 'wso2carbon'
-  $binary_agent_trust_store = '${sys:carbon.home}/resources/security/client-truststore.jks'
-  $binary_agent_trust_store_password = 'wso2carbon'
-
-  # wso2.securevault
-  $securevault_private_key_alias = 'wso2carbon'
-  $securevault_key_store = '${sys:carbon.home}/resources/security/securevault.jks'
-  $securevault_secret_properties_file = '${sys:carbon.home}/conf/${sys:wso2.runtime}/secrets.properties'
-  $securevault_master_key_reader_file = '${sys:carbon.home}/conf/${sys:wso2.runtime}/master-keys.yaml'
 
   # wso2.datasources
   $dashboard_db_url = 'jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/DASHBOARD_DB;IFEXISTS=TRUE;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;MVCC=TRUE'

--- a/modules/sp_dashboard_master/templates/carbon-home/conf/dashboard/deployment.yaml.erb
+++ b/modules/sp_dashboard_master/templates/carbon-home/conf/dashboard/deployment.yaml.erb
@@ -197,7 +197,7 @@ wso2.securevault:
     type: org.wso2.carbon.secvault.repository.DefaultSecretRepository
     parameters:
       privateKeyAlias: <%= @securevault_private_key_alias %>
-      keystoreLocation: <%= @securevault_key_store %>
+      keystoreLocation: <%= @securevault_keystore %>
       secretPropertiesFile: <%= @securevault_secret_properties_file %>
   masterKeyReader:
     type: org.wso2.carbon.secvault.reader.DefaultMasterKeyReader

--- a/modules/sp_editor/manifests/init.pp
+++ b/modules/sp_editor/manifests/init.pp
@@ -46,7 +46,7 @@ class sp_editor inherits sp_editor::params {
   # Copy JDK to Java distribution path
   file { "jdk-distribution":
     path   => "${java_home}.tar.gz",
-    source => "puppet:///modules/distributions/${jdk_name}.tar.gz",
+    source => "puppet:///modules/common/${jdk_name}.tar.gz",
   }
 
   # Unzip distribution

--- a/modules/sp_editor/manifests/init.pp
+++ b/modules/sp_editor/manifests/init.pp
@@ -148,6 +148,13 @@ class sp_editor inherits sp_editor::params {
     content => template("${module_name}/${service_name}.service.erb"),
   }
 
+  # Add agent specific file configurations
+  # $config_file_list.each |$config_file| {
+  #   exec { "sed -i -e 's/${config_file['key']}/${config_file['value']}/g' ${config_file['file']}":
+  #     path => "/bin/",
+  #   }
+  # }
+
   /*
     Following script can be used to copy file to a given location.
     This will copy some_file to install_path -> repository.

--- a/modules/sp_editor/manifests/params.pp
+++ b/modules/sp_editor/manifests/params.pp
@@ -44,4 +44,21 @@ class sp_editor::params {
   $product_binary = "${product}-${product_version}.zip"
   $distribution_path = "${products_dir}/${product}/${product_profile}/${product_version}"
   $install_path = "${distribution_path}/${product}-${product_version}"
+
+  # List of files that must contain agent specific configuraitons
+  # if $deployment == "dev" {
+  #   $config_file_list = [
+  #     { "file" => "${install_path}/file1", "key" => "key1", "value" => "value1" },
+  #   ]
+  # }
+  # elsif $deployment == "staging" {
+  #   $config_file_list = [
+  #     { "file" => "${install_path}/file1", "key" => "key1", "value" => "value1" },
+  #   ]
+  # }
+  # elsif $deployment == "production" {
+  #   $config_file_list = [
+  #     { "file" => "${install_path}/file1", "key" => "key1", "value" => "value1" },
+  #   ]
+  # }
 }

--- a/modules/sp_editor_master/manifests/init.pp
+++ b/modules/sp_editor_master/manifests/init.pp
@@ -30,7 +30,7 @@ class sp_editor_master inherits sp_editor_master::params {
   file { "binary":
     path   => "${distribution_path}/${product_binary}",
     mode   => '0644',
-    source => "puppet:///modules/distributions/${product_binary}",
+    source => "puppet:///modules/common/${product_binary}",
   }
 
   # Install the "unzip" package

--- a/modules/sp_editor_master/manifests/params.pp
+++ b/modules/sp_editor_master/manifests/params.pp
@@ -16,7 +16,7 @@
 
 # Claas sp_editor_master::params
 # This class includes all the necessary parameters
-class sp_editor_master::params {
+class sp_editor_master::params inherits common::params {
   $user = 'wso2carbon'
   $user_group = 'wso2'
   $product = 'wso2sp'
@@ -37,23 +37,6 @@ class sp_editor_master::params {
   $msf4j_cert_pass = 'wso2carbon'
 
   $siddhi_default_host = '0.0.0.0'
-
-  # Configuration used for the databridge communication
-  $databridge_keystore_location = '${sys:carbon.home}/resources/security/wso2carbon.jks'
-  $databridge_keystore_password = 'wso2carbon'
-  $binary_data_receiver_hostname = '0.0.0.0'
-
-  # Configuration of the Data Agents - to publish events through databridge
-  $thrift_agent_trust_store = '${sys:carbon.home}/resources/security/client-truststore.jks'
-  $thrift_agent_trust_store_password = 'wso2carbon'
-  $binary_agent_trust_store = '${sys:carbon.home}/resources/security/client-truststore.jks'
-  $binary_agent_trust_store_password = 'wso2carbon'
-
-  # Secure Vault Configuration
-  $securevault_private_key_alias = 'wso2carbon'
-  $securevault_keystore = '${sys:carbon.home}/resources/security/securevault.jks'
-  $securevault_secret_properties_file = '${sys:carbon.home}/conf/${sys:wso2.runtime}/secrets.properties'
-  $securevault_master_key_reader_file = '${sys:carbon.home}/conf/${sys:wso2.runtime}/master-keys.yaml'
 
   # Datasource Configurations
   $carbon_db_url = 'jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/WSO2_CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000'

--- a/modules/sp_manager/manifests/init.pp
+++ b/modules/sp_manager/manifests/init.pp
@@ -46,7 +46,7 @@ class sp_manager inherits sp_manager::params {
   # Copy JDK to Java distribution path
   file { "jdk-distribution":
     path   => "${java_home}.tar.gz",
-    source => "puppet:///modules/distributions/${jdk_name}.tar.gz",
+    source => "puppet:///modules/common/${jdk_name}.tar.gz",
   }
 
   # Unzip distribution

--- a/modules/sp_manager/manifests/init.pp
+++ b/modules/sp_manager/manifests/init.pp
@@ -148,6 +148,13 @@ class sp_manager inherits sp_manager::params {
     content => template("${module_name}/${service_name}.service.erb"),
   }
 
+  # Add agent specific file configurations
+  # $config_file_list.each |$config_file| {
+  #   exec { "sed -i -e 's/${config_file['key']}/${config_file['value']}/g' ${config_file['file']}":
+  #     path => "/bin/",
+  #   }
+  # }
+
   /*
     Following script can be used to copy file to a given location.
     This will copy some_file to install_path -> repository.

--- a/modules/sp_manager/manifests/params.pp
+++ b/modules/sp_manager/manifests/params.pp
@@ -44,4 +44,21 @@ class sp_manager::params {
   $product_binary = "${product}-${product_version}.zip"
   $distribution_path = "${products_dir}/${product}/${product_profile}/${product_version}"
   $install_path = "${distribution_path}/${product}-${product_version}"
+
+  # List of files that must contain agent specific configuraitons
+  # if $deployment == "dev" {
+  #   $config_file_list = [
+  #     { "file" => "${install_path}/file1", "key" => "key1", "value" => "value1" },
+  #   ]
+  # }
+  # elsif $deployment == "staging" {
+  #   $config_file_list = [
+  #     { "file" => "${install_path}/file1", "key" => "key1", "value" => "value1" },
+  #   ]
+  # }
+  # elsif $deployment == "production" {
+  #   $config_file_list = [
+  #     { "file" => "${install_path}/file1", "key" => "key1", "value" => "value1" },
+  #   ]
+  # }
 }

--- a/modules/sp_manager_master/manifests/init.pp
+++ b/modules/sp_manager_master/manifests/init.pp
@@ -30,7 +30,7 @@ class sp_manager_master inherits sp_manager_master::params {
   file { "binary":
     path   => "${distribution_path}/${product_binary}",
     mode   => '0644',
-    source => "puppet:///modules/distributions/${product_binary}",
+    source => "puppet:///modules/common/${product_binary}",
   }
 
   # Install the "unzip" package

--- a/modules/sp_manager_master/manifests/params.pp
+++ b/modules/sp_manager_master/manifests/params.pp
@@ -16,7 +16,7 @@
 
 # Claas sp_manager_master::params
 # This class includes all the necessary parameters
-class sp_manager_master::params {
+class sp_manager_master::params inherits common::params {
   $user = 'wso2carbon'
   $user_group = 'wso2'
   $product = 'wso2sp'
@@ -35,23 +35,6 @@ class sp_manager_master::params {
   $msf4j_keystore_file = '${carbon.home}/resources/security/wso2carbon.jks'
   $msf4j_keystore_password = 'wso2carbon'
   $msf4j_cert_pass = 'wso2carbon'
-
-  # Configuration used for the databridge communication
-  $databridge_keystore_location = '${sys:carbon.home}/resources/security/wso2carbon.jks'
-  $databridge_keystore_password = 'wso2carbon'
-  $binary_data_receiver_hostname = '0.0.0.0'
-
-  # Configuration of the Data Agents - to publish events through databridge
-  $thrift_agent_trust_store = '${sys:carbon.home}/resources/security/client-truststore.jks'
-  $thrift_agent_trust_store_password = 'wso2carbon'
-  $binary_agent_trust_store = '${sys:carbon.home}/resources/security/client-truststore.jks'
-  $binary_agent_trust_store_password = 'wso2carbon'
-
-  # Secure Vault Configuration
-  $securevault_private_key_alias = 'wso2carbon'
-  $securevault_keystore = '${sys:carbon.home}/resources/security/securevault.jks'
-  $securevault_secret_properties_file = '${sys:carbon.home}/conf/${sys:wso2.runtime}/secrets.properties'
-  $securevault_master_key_reader_file = '${sys:carbon.home}/conf/${sys:wso2.runtime}/master-keys.yaml'
 
   # Datasource Configurations
   $mgt_db_url = 'jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/SP_MGT_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000'

--- a/modules/sp_worker/manifests/init.pp
+++ b/modules/sp_worker/manifests/init.pp
@@ -148,6 +148,13 @@ class sp_worker inherits sp_worker::params {
     content => template("${module_name}/${service_name}.service.erb"),
   }
 
+  # Add agent specific file configurations
+  # $config_file_list.each |$config_file| {
+  #   exec { "sed -i -e 's/${config_file['key']}/${config_file['value']}/g' ${config_file['file']}":
+  #     path => "/bin/",
+  #   }
+  # }
+
   /*
     Following script can be used to copy file to a given location.
     This will copy some_file to install_path -> repository.

--- a/modules/sp_worker/manifests/init.pp
+++ b/modules/sp_worker/manifests/init.pp
@@ -46,7 +46,7 @@ class sp_worker inherits sp_worker::params {
   # Copy JDK to Java distribution path
   file { "jdk-distribution":
     path   => "${java_home}.tar.gz",
-    source => "puppet:///modules/distributions/${jdk_name}.tar.gz",
+    source => "puppet:///modules/common/${jdk_name}.tar.gz",
   }
 
   # Unzip distribution

--- a/modules/sp_worker/manifests/params.pp
+++ b/modules/sp_worker/manifests/params.pp
@@ -44,4 +44,21 @@ class sp_worker::params {
   $product_binary = "${product}-${product_version}.zip"
   $distribution_path = "${products_dir}/${product}/${product_profile}/${product_version}"
   $install_path = "${distribution_path}/${product}-${product_version}"
+
+  # List of files that must contain agent specific configuraitons
+  # if $deployment == "dev" {
+  #   $config_file_list = [
+  #     { "file" => "${install_path}/file1", "key" => "key1", "value" => "value1" },
+  #   ]
+  # }
+  # elsif $deployment == "staging" {
+  #   $config_file_list = [
+  #     { "file" => "${install_path}/file1", "key" => "key1", "value" => "value1" },
+  #   ]
+  # }
+  # elsif $deployment == "production" {
+  #   $config_file_list = [
+  #     { "file" => "${install_path}/file1", "key" => "key1", "value" => "value1" },
+  #   ]
+  # }
 }

--- a/modules/sp_worker_master/manifests/init.pp
+++ b/modules/sp_worker_master/manifests/init.pp
@@ -30,7 +30,7 @@ class sp_worker_master inherits sp_worker_master::params {
   file { "binary":
     path   => "${distribution_path}/${product_binary}",
     mode   => '0644',
-    source => "puppet:///modules/distributions/${product_binary}",
+    source => "puppet:///modules/common/${product_binary}",
   }
 
   # Install the "unzip" package

--- a/modules/sp_worker_master/manifests/params.pp
+++ b/modules/sp_worker_master/manifests/params.pp
@@ -16,7 +16,7 @@
 
 # Claas sp_worker_master::params
 # This class includes all the necessary parameters
-class sp_worker_master::params {
+class sp_worker_master::params inherits common::params {
   $user = 'wso2carbon'
   $user_group = 'wso2'
   $product = 'wso2sp'
@@ -40,23 +40,6 @@ class sp_worker_master::params {
   $siddhi_msf4j_keystore = '${carbon.home}/resources/security/wso2carbon.jks'
   $siddhi_msf4j_keystore_password = 'wso2carbon'
   $siddhi_msf4j_cert_pass = 'wso2carbon'
-
-  # Configuration used for the databridge communication
-  $databridge_keystore_location = '${sys:carbon.home}/resources/security/wso2carbon.jks'
-  $databridge_keystore_password = 'wso2carbon'
-  $binary_data_receiver_hostname = '0.0.0.0'
-
-  # Configuration of the Data Agents - to publish events through databridge
-  $thrift_agent_trust_store = '${sys:carbon.home}/resources/security/client-truststore.jks'
-  $thrift_agent_trust_store_password = 'wso2carbon'
-  $binary_agent_trust_store = '${sys:carbon.home}/resources/security/client-truststore.jks'
-  $binary_agent_trust_store_password = 'wso2carbon'
-
-  # Secure Vault Configuration
-  $securevault_private_key_alias = 'wso2carbon'
-  $securevault_keystore = '${sys:carbon.home}/resources/security/securevault.jks'
-  $securevault_secret_properties_file = '${sys:carbon.home}/conf/${sys:wso2.runtime}/secrets.properties'
-  $securevault_master_key_reader_file = '${sys:carbon.home}/conf/${sys:wso2.runtime}/master-keys.yaml'
 
   # Datasource Configurations
   $carbon_db_url = 'jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/WSO2_CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000'


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/wso2/puppet-sp/issues/10, Resolves https://github.com/wso2/puppet-sp/issues/11

## Goals
> Create a "common" module which hosts the files, and parameters common to all profiles.
> Add agent specific configurations

## Test environment
> Puppet 5.4.0
> Ubuntu 18.04